### PR TITLE
Fix config path quoting

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,9 +1,9 @@
 # Example configuration for phase4v2.py
 # Adjust the paths as needed. Below reflects the original dataset location used
 # when `phase4_famd.py` was created.
-input_file: "D:\DATAPREDICT\DATAPREDICT 2024\Missions\Digora\export_everwin (19).xlsx"
-output_dir: "D:\DATAPREDICT\DATAPREDICT 2024\Missions\Digora\phase4_output"
-metrics_dir: "D:\DATAPREDICT\DATAPREDICT 2024\Missions\Digora\METRICS_DIR"
+input_file: 'D:\DATAPREDICT\DATAPREDICT 2024\Missions\Digora\export_everwin (19).xlsx'
+output_dir: 'D:\DATAPREDICT\DATAPREDICT 2024\Missions\Digora\phase4_output'
+metrics_dir: 'D:\DATAPREDICT\DATAPREDICT 2024\Missions\Digora\METRICS_DIR'
 methods: [famd, mfa, pcamix, umap, tsne]
 
 # Method specific options (can be left empty)


### PR DESCRIPTION
## Summary
- fix Windows path quoting in example config

## Testing
- `python phase4v2.py --config config.yaml` *(fails: FileNotFoundError for input file)*
- `python test_run_famd.py`