### PR TITLE
Fix evaluate_methods with None inertia

### DIFF
--- a/phase4v2.py
+++ b/phase4v2.py
@@ -1095,6 +1095,8 @@ def evaluate_methods(
     rows = []
     for method, info in results_dict.items():
         inertias = info.get("inertia", [])
+        if inertias is None:
+            inertias = []
         if isinstance(inertias, pd.Series):
             inertias = inertias.tolist()
         kaiser = sum(1 for eig in inertias if eig > 1)


### PR DESCRIPTION
## Summary
- handle `None` inertia values when evaluating methods in `phase4v2.py`

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*