### PR TITLE
Fix MFA scree plot output directory

### DIFF
--- a/phase4v2.py
+++ b/phase4v2.py
@@ -530,6 +530,7 @@ def run_mfa(
     plt.title("Éboulis MFA")
     plt.xticks(axes)
     plt.tight_layout()
+    output_dir.mkdir(parents=True, exist_ok=True)
     plt.savefig(output_dir / "mfa_scree_plot.png")
     plt.close()
 


### PR DESCRIPTION
## Summary
- ensure the output directory for MFA exists before saving the scree plot

## Testing
- `python test_run_famd.py`