### PR TITLE
Add hyperparameter auto-tuning for dimensionality reduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ is provided in `config.yaml`. Copy or modify it to suit your dataset and run:
 python phase4v2.py --config config.yaml
 ```
 
+Set `optimize_params: true` in the configuration to automatically tune the main
+hyperparameters of each dimensionality reduction method (number of components
+for FAMD/MFA/PCAmix, neighbors and distance for UMAP, perplexity for t-SNE).
+When disabled, the script uses the provided values or sensible defaults.
+
 Make sure the dependencies listed in `requirements.txt` are installed. The
 package `umap-learn` is required for the UMAP functionality.
 

--- a/config.yaml
+++ b/config.yaml
@@ -4,6 +4,7 @@
 input_file: 'D:\DATAPREDICT\DATAPREDICT 2024\Missions\Digora\export_everwin (19).xlsx'
 output_dir: 'D:\DATAPREDICT\DATAPREDICT 2024\Missions\Digora\phase4_output'
 metrics_dir: 'D:\DATAPREDICT\DATAPREDICT 2024\Missions\Digora\METRICS_DIR'
+optimize_params: false
 methods: [famd, mfa, pcamix, umap, tsne]
 
 # Method specific options (can be left empty)

--- a/phase4v2.py
+++ b/phase4v2.py
@@ -484,7 +484,8 @@ def run_mfa(
         quant_vars: List[str],
         qual_vars: List[str],
         output_dir: Path,
-        n_components: int = 5
+        n_components: Optional[int] = None,
+        optimize: bool = False,
 ) -> Tuple[prince.MFA, pd.DataFrame]:
     """Exécute une MFA sur le jeu de données mixte.
 
@@ -494,6 +495,8 @@ def run_mfa(
         qual_vars: Liste des noms de colonnes qualitatives.
         output_dir: Répertoire où sauver les graphiques.
         n_components: Nombre de composantes factorielles à extraire.
+        optimize: Si ``True`` et ``n_components`` est ``None``, choisit
+            automatiquement le nombre d'axes (90 % de variance cumulée).
 
     Returns:
         - L’objet prince.MFA entraîné.
@@ -515,7 +518,24 @@ def run_mfa(
     # Combine numeric columns with the dummy-encoded qualitative variables
     df_mfa = pd.concat([df_active[quant_vars], df_dummies], axis=1)
 
-    mfa = prince.MFA(n_components=n_components)
+    logger = logging.getLogger(__name__)
+
+    n_comp = n_components
+    if optimize and n_components is None:
+        n_init = df_mfa.shape[1]
+        tmp = prince.MFA(n_components=n_init).fit(df_mfa, groups=groups)
+        inertia_tmp = tmp.percentage_of_variance_ / 100
+        cum = np.cumsum(inertia_tmp)
+        n_comp = next((i + 1 for i, v in enumerate(cum) if v >= 0.9), n_init)
+        logger.info(
+            "MFA auto: %d composantes retenues (%.1f%% variance cumulée)",
+            n_comp,
+            cum[n_comp - 1] * 100,
+        )
+
+    n_comp = n_comp or 5
+
+    mfa = prince.MFA(n_components=n_comp)
     mfa = mfa.fit(df_mfa, groups=groups)
     row_coords = mfa.row_coordinates(df_mfa)
 
@@ -542,7 +562,8 @@ def run_pcamix(
         quant_vars: List[str],
         qual_vars: List[str],
         output_dir: Path,
-        n_components: int = 5,
+        n_components: Optional[int] = None,
+        optimize: bool = False,
 ) -> Tuple[prince.FAMD, pd.Series, pd.DataFrame, pd.DataFrame]:
     """Exécute une analyse de type PCAmix via :class:`prince.FAMD`."""
 
@@ -563,9 +584,30 @@ def run_pcamix(
         axis=1,
     )
 
+    n_comp = n_components
+    if optimize and n_components is None:
+        n_init = df_mix.shape[1]
+        tmp = prince.FAMD(
+            n_components=n_init,
+            n_iter=3,
+            copy=True,
+            check_input=True,
+            engine="sklearn",
+        ).fit(df_mix)
+        inertia_tmp = get_explained_inertia(tmp)
+        cum = np.cumsum(inertia_tmp)
+        n_comp = next((i + 1 for i, v in enumerate(cum) if v >= 0.9), n_init)
+        logger.info(
+            "PCAmix auto: %d composantes retenues (%.1f%% variance cumulée)",
+            n_comp,
+            cum[n_comp - 1] * 100,
+        )
+
+    n_comp = n_comp or 5
+
     # 3) FAMD (équivalent PCAmix)
     md_pca = prince.FAMD(
-        n_components=n_components,
+        n_components=n_comp,
         n_iter=3,
         copy=True,
         check_input=True,
@@ -609,11 +651,13 @@ def run_tsne(
         embeddings: pd.DataFrame,
         df_active: pd.DataFrame,
         output_dir: Path,
-        perplexity: int = 30,
+        perplexity: Optional[int] = None,
         learning_rate: float = 200.0,
         n_iter: int = 1_000,
         random_state: int = 42,
         n_components: int = 2,
+        optimize: bool = False,
+        perplexity_grid: Sequence[int] | None = None,
 ) -> Tuple[TSNE, pd.DataFrame]:
     """
     Applique t-SNE sur des coordonnées factorielles existantes et renvoie les
@@ -628,8 +672,9 @@ def run_tsne(
         DataFrame complet pour récupérer la variable ``Statut commercial``.
     output_dir : Path
         Répertoire des résultats (créé dans ``main``).
-    perplexity : int
-        Paramètre "voisinage" du t-SNE.
+    perplexity : int, optional
+        Paramètre "voisinage" du t-SNE. S'il est omis et ``optimize`` vaut
+        ``True``, une recherche simple est effectuée.
     learning_rate : float
         Taux d'apprentissage du t-SNE.
     n_iter : int
@@ -638,6 +683,10 @@ def run_tsne(
         Graine pour la reproductibilité.
     n_components : int
         Dimension de la projection t-SNE (2 ou 3).
+    optimize : bool
+        Active l'optimisation automatique de ``perplexity``.
+    perplexity_grid : Sequence[int], optional
+        Valeurs testées si ``perplexity`` n'est pas fourni.
 
     Returns:
     -------
@@ -645,28 +694,49 @@ def run_tsne(
         L'instance :class:`TSNE` ajustée et le ``DataFrame`` des embeddings
         (colonnes ``TSNE1``, ``TSNE2`` (, ``TSNE3``)).
     """
-    # 2.1 Instanciation
-    try:
-        tsne = TSNE(
-            n_components=n_components,
-            perplexity=perplexity,
-            learning_rate=learning_rate,
-            max_iter=n_iter,
-            random_state=random_state,
-            init="pca",
-        )
-    except TypeError:  # pragma: no cover - older scikit-learn
-        tsne = TSNE(
-            n_components=n_components,
-            perplexity=perplexity,
-            learning_rate=learning_rate,
-            n_iter=n_iter,
-            random_state=random_state,
-            init="pca",
-        )
+    logger = logging.getLogger(__name__)
+    perpl = perplexity if perplexity is not None else 30
 
-    # 2.2 Fit & transform
-    tsne_results = tsne.fit_transform(embeddings.values)
+    def _fit_tsne(p):
+        try:
+            t = TSNE(
+                n_components=n_components,
+                perplexity=p,
+                learning_rate=learning_rate,
+                max_iter=n_iter,
+                random_state=random_state,
+                init="pca",
+            )
+        except TypeError:  # pragma: no cover - older scikit-learn
+            t = TSNE(
+                n_components=n_components,
+                perplexity=p,
+                learning_rate=learning_rate,
+                n_iter=n_iter,
+                random_state=random_state,
+                init="pca",
+            )
+        emb = t.fit_transform(embeddings.values)
+        return t, emb
+
+    if optimize and perplexity is None:
+        from sklearn.manifold import trustworthiness
+
+        grid = perplexity_grid or [5, 30, 50]
+        best = None
+        for p in grid:
+            t, emb = _fit_tsne(p)
+            score = trustworthiness(embeddings.values, emb)
+            if best is None or score > best[0]:
+                best = (score, p, t, emb)
+        best_score, perpl, tsne, tsne_results = best
+        logger.info(
+            "t-SNE optimal: perplexity=%d (trustworthiness=%.3f)",
+            perpl,
+            best_score,
+        )
+    else:
+        tsne, tsne_results = _fit_tsne(perpl)
 
     # 2.3 DataFrame t-SNE
     cols = [f"TSNE{i + 1}" for i in range(n_components)]
@@ -728,11 +798,12 @@ def run_umap(
         quant_vars: List[str],
         qual_vars: List[str],
         output_dir: Path,
-        n_neighbors: int = 15,
-        min_dist: float = 0.1,
+        n_neighbors: Optional[int] = None,
+        min_dist: Optional[float] = None,
         n_components: int = 2,
         random_state: int | None = 42,
         n_jobs: int | None = None,
+        optimize: bool = False,
 ) -> Tuple[umap.UMAP, pd.DataFrame]:
     """
     Exécute UMAP sur un jeu mixte de variables quantitatives et qualitatives.
@@ -751,6 +822,8 @@ def run_umap(
         n_jobs: Nombre de threads UMAP. Si ``random_state`` est défini et
             ``n_jobs`` n'est pas ``1``, la valeur sera forcée à ``1`` pour
             éviter le warning de ``umap-learn``.
+        optimize: si ``True`` et que ``n_neighbors``/``min_dist`` ne sont pas
+            fournis, recherche la meilleure combinaison (trustworthiness).
 
     Returns:
         - L’objet UMAP entraîné,
@@ -778,24 +851,54 @@ def run_umap(
 
     logger = logging.getLogger(__name__)
 
-    # 2.4 Exécution de UMAP
-    if random_state is not None:
-        if n_jobs not in (None, 1):
-            logger.warning(
-                "random_state défini (%s) : n_jobs=%s forcé à 1 pour garantir la reproductibilité",
-                random_state,
-                n_jobs,
-            )
-        n_jobs = 1
+    n_neigh = n_neighbors if n_neighbors is not None else 15
+    dist = min_dist if min_dist is not None else 0.1
 
-    reducer = umap.UMAP(
-        n_neighbors=n_neighbors,
-        min_dist=min_dist,
-        n_components=n_components,
-        random_state=random_state,
-        n_jobs=n_jobs,
-    )
-    embedding = reducer.fit_transform(X_mix)
+    def _build_umap(nn, md):
+        nj = n_jobs
+        if random_state is not None:
+            if nj not in (None, 1):
+                logger.warning(
+                    "random_state défini (%s) : n_jobs=%s forcé à 1 pour garantir la reproductibilité",
+                    random_state,
+                    nj,
+                )
+            nj = 1
+        return umap.UMAP(
+            n_neighbors=nn,
+            min_dist=md,
+            n_components=n_components,
+            random_state=random_state,
+            n_jobs=nj,
+        )
+
+    if optimize and (n_neighbors is None or min_dist is None):
+        from joblib import Parallel, delayed
+        from sklearn.manifold import trustworthiness
+
+        neigh_grid = [5, 15, 30, 50] if n_neighbors is None else [n_neighbors]
+        dist_grid = [0.1, 0.5] if min_dist is None else [min_dist]
+
+        def eval_combo(nn, md):
+            reducer = _build_umap(nn, md)
+            emb = reducer.fit_transform(X_mix)
+            score = trustworthiness(X_mix, emb)
+            return score, nn, md, emb, reducer
+
+        results = Parallel(n_jobs=-1)(
+            delayed(eval_combo)(nn, md) for nn in neigh_grid for md in dist_grid
+        )
+        best = max(results, key=lambda x: x[0])
+        best_score, n_neigh, dist, embedding, reducer = best
+        logger.info(
+            "UMAP optimal: n_neighbors=%d, min_dist=%.2f (trustworthiness=%.3f)",
+            n_neigh,
+            dist,
+            best_score,
+        )
+    else:
+        reducer = _build_umap(n_neigh, dist)
+        embedding = reducer.fit_transform(X_mix)
 
     # 2.5 Mise en DataFrame
     cols = [f"UMAP{i + 1}" for i in range(n_components)]
@@ -878,7 +981,8 @@ def run_famd(
         quant_vars: List[str],
         qual_vars: List[str],
         n_components: Optional[int] = None,
-        famd_cfg: dict = None
+        famd_cfg: dict = None,
+        optimize: bool = False,
 ) -> Tuple[
     prince.FAMD,
     pd.Series,
@@ -900,6 +1004,9 @@ def run_famd(
     n_components : int, optional
         Nombre de composantes factorielles à extraire. Si None, utilise toutes les composantes possibles.
     famd_cfg:  dict
+    optimize : bool
+        Si ``True`` et ``n_components`` est ``None``, choisit automatiquement le
+        nombre d'axes en fonction de la variance expliquée (seuil 90 %).
 
     Returns
     -------
@@ -938,8 +1045,31 @@ def run_famd(
     cfg = famd_cfg or {}
     weighting = cfg.get('weighting', 'balanced')  # 'balanced' | 'auto' | 'manual'
 
+    n_comp = n_components
+
+    if optimize and n_components is None:
+        # Exploration avec le nombre maximal de composantes pour estimer la variance
+        n_init = df_for_famd.shape[1]
+        tmp = prince.FAMD(
+            n_components=n_init,
+            n_iter=3,
+            copy=True,
+            check_input=True,
+            engine='sklearn'
+        ).fit(df_for_famd)
+        inertia_tmp = get_explained_inertia(tmp)
+        cum = np.cumsum(inertia_tmp)
+        thresh = 0.9
+        n_comp = next((i + 1 for i, v in enumerate(cum) if v >= thresh), n_init)
+        logger.info(
+            "FAMD auto: %d composantes retenues (%.1f%% variance cumulée)",
+            n_comp,
+            cum[n_comp - 1] * 100
+        )
+
+    n_comp = n_comp or df_for_famd.shape[1]
+
     # 3b) Initialisation de l’AFDM
-    n_comp = n_components or df_for_famd.shape[1]
     famd = prince.FAMD(
         n_components=n_comp,
         n_iter=3,
@@ -1743,13 +1873,18 @@ def main() -> None:
 
     segment_data(df_active, qual_vars, output_dir)
 
+    optimize_params = config.get("optimize_params", False)
     results: Dict[str, Dict[str, Any]] = {}
 
     # 2. FAMD
     if "famd" in config.get("methods", []):
         t0 = time.time()
         famd_model, famd_inertia, famd_rows, famd_cols, famd_contrib = run_famd(
-            df_active, quant_vars, qual_vars, **config.get("famd", {})
+            df_active,
+            quant_vars,
+            qual_vars,
+            optimize=optimize_params,
+            **config.get("famd", {})
         )
         rt = time.time() - t0
         results["FAMD"] = {
@@ -1781,7 +1916,12 @@ def main() -> None:
         t0 = time.time()
         output_dir_mfa = output_dir / "MFA"
         mfa_model, mfa_rows = run_mfa(
-            df_active, quant_vars, qual_vars, output_dir_mfa, **config.get("mfa", {})
+            df_active,
+            quant_vars,
+            qual_vars,
+            output_dir_mfa,
+            optimize=optimize_params,
+            **config.get("mfa", {})
         )
         rt = time.time() - t0
         results["MFA"] = {
@@ -1809,7 +1949,12 @@ def main() -> None:
         t0 = time.time()
         output_dir_pcamix = output_dir / "PCAmix"
         mdpca_model, mdpca_inertia, mdpca_rows, mdpca_cols = run_pcamix(
-            df_active, quant_vars, qual_vars, output_dir_pcamix, **config.get("pcamix", {})
+            df_active,
+            quant_vars,
+            qual_vars,
+            output_dir_pcamix,
+            optimize=optimize_params,
+            **config.get("pcamix", {})
         )
         rt = time.time() - t0
         results["PCAmix"] = {
@@ -1843,6 +1988,7 @@ def main() -> None:
             quant_vars,
             qual_vars,
             output_dir_umap,
+            optimize=optimize_params,
             **config.get("umap", {}),
         )
         export_umap_results(umap_df, df_active, output_dir_umap)
@@ -1852,7 +1998,13 @@ def main() -> None:
             "inertia": None,
             "runtime": rt,
         }
-        logger.info("UMAP : %d composantes, %.1fs", umap_model.n_components, rt)
+        logger.info(
+            "UMAP : %d composantes, n_neighbors=%d, min_dist=%.2f, %.1fs",
+            umap_model.n_components,
+            getattr(umap_model, "n_neighbors", -1),
+            getattr(umap_model, "min_dist", 0.0),
+            rt,
+        )
 
     # 6. t-SNE
     if "tsne" in config.get("methods", []):
@@ -1861,7 +2013,11 @@ def main() -> None:
         t0 = time.time()
         output_dir_tsne = output_dir / "TSNE"
         tsne_model, tsne_df = run_tsne(
-            results["FAMD"]["embeddings"], df_active, output_dir_tsne, **config.get("tsne", {})
+            results["FAMD"]["embeddings"],
+            df_active,
+            output_dir_tsne,
+            optimize=optimize_params,
+            **config.get("tsne", {})
         )
         export_tsne_results(tsne_df, df_active, output_dir_tsne)
         rt = time.time() - t0
@@ -1870,7 +2026,11 @@ def main() -> None:
             "inertia": None,
             "runtime": rt,
         }
-        logger.info("t-SNE : %.1fs", rt)
+        logger.info(
+            "t-SNE : perplexity=%s, %.1fs",
+            getattr(tsne_model, "perplexity", "?"),
+            rt,
+        )
 
     # 7. Évaluation croisée
     comp_df = evaluate_methods(results, output_dir, n_clusters=3)


### PR DESCRIPTION
## Summary
- support automatic parameter tuning through `optimize_params`
- auto-select number of components for FAMD, MFA and PCAmix
- grid search for UMAP neighbours and min_dist
- grid search for t-SNE perplexity
- document the new option and update default config

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python test_run_famd.py`