### PR TITLE
Fix Tk backend cleanup warnings

### DIFF
--- a/phase4v2.py
+++ b/phase4v2.py
@@ -15,6 +15,9 @@ except ValueError as err:
     raise
 from PIL import Image
 import io
+import matplotlib
+# Use a non-interactive backend to avoid Tkinter cleanup errors in CLI usage
+matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 from matplotlib.backends.backend_pdf import PdfPages
 from typing import List, Optional, Tuple, Sequence, Dict, Any


### PR DESCRIPTION
## Summary
- use non-interactive Matplotlib backend to avoid Tkinter warnings

## Testing
- `python test_run_famd.py`
- `python test_run_pcamix.py`
