### PR TITLE
Expose UMAP metric parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ python -m pip install --force-reinstall -r requirements.txt
 
 The package `umap-learn` is required for the UMAP functionality. `phate` and
 `pacmap` are optional; install them if you want to run the corresponding
-analyses.
+analyses. UMAP accepts several parameters in `config.yaml`, including
+`n_neighbors`, `min_dist` and the distance `metric` (default `euclidean`).
 
 ### UMAP warnings
 

--- a/config.yaml
+++ b/config.yaml
@@ -18,5 +18,6 @@ umap:
   # this case, preventing a warning from the library.
   random_state: 42
   n_jobs: 1
+  metric: euclidean
 tsne: {}
 phate: {}

--- a/phase4v2.py
+++ b/phase4v2.py
@@ -988,6 +988,7 @@ def run_umap(
         n_components: int = 2,
         random_state: int | None = 42,
         n_jobs: int | None = None,
+        metric: str = "euclidean",
         optimize: bool = False,
 ) -> Tuple[umap.UMAP, pd.DataFrame]:
     """
@@ -1007,6 +1008,8 @@ def run_umap(
         n_jobs: Nombre de threads UMAP. Si ``random_state`` est défini et
             ``n_jobs`` n'est pas ``1``, la valeur sera forcée à ``1`` pour
             éviter le warning de ``umap-learn``.
+        metric: Fonction de distance à utiliser ("euclidean", "manhattan",
+            "cosine", ...).
         optimize: si ``True`` et que ``n_neighbors``/``min_dist`` ne sont pas
             fournis, recherche la meilleure combinaison (trustworthiness).
 
@@ -1055,6 +1058,7 @@ def run_umap(
             n_components=n_components,
             random_state=random_state,
             n_jobs=nj,
+            metric=metric,
         )
 
     if optimize and (n_neighbors is None or min_dist is None):
@@ -2884,6 +2888,7 @@ def main() -> None:
             "n_components": umap_model.n_components,
             "n_neighbors": getattr(umap_model, "n_neighbors", None),
             "min_dist": getattr(umap_model, "min_dist", None),
+            "metric": getattr(umap_model, "metric", None),
         })
 
     # 8. PaCMAP


### PR DESCRIPTION
## Summary
- let run_umap specify the UMAP distance metric
- document UMAP parameters in README
- add default `metric: euclidean` entry in `config.yaml`

## Testing
- `pytest -q`