### PR TITLE
Add standalone scripts for dimensionality methods

### DIFF
--- a/phase4_mca.py
+++ b/phase4_mca.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Standalone MCA analysis using functions from phase4v2."""
+
+import argparse
+import logging
+from pathlib import Path
+
+from phase4v2 import run_mca, export_mca_results
+from standalone_utils import prepare_active_dataset
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run MCA only")
+    parser.add_argument("--input", required=True, help="Excel file")
+    parser.add_argument("--output", required=True, help="Output directory")
+    parser.add_argument("--n_components", type=int, default=None, help="Number of components")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+    out_dir = Path(args.output) / "MCA"
+
+    df_active, quant_vars, qual_vars = prepare_active_dataset(args.input, out_dir)
+
+    model, inertia, rows, cols, contrib = run_mca(
+        df_active,
+        quant_vars,
+        qual_vars,
+        out_dir,
+        n_components=args.n_components,
+    )
+
+    export_mca_results(model, inertia, rows, cols, out_dir, qual_vars, df_active=df_active)
+    logging.info("MCA analysis complete")
+
+
+if __name__ == "__main__":
+    main()

--- a/phase4_mfa.py
+++ b/phase4_mfa.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Standalone MFA analysis using functions from phase4v2."""
+
+import argparse
+import logging
+from pathlib import Path
+
+from phase4v2 import run_mfa, export_mfa_results
+from standalone_utils import prepare_active_dataset
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run MFA only")
+    parser.add_argument("--input", required=True, help="Excel file")
+    parser.add_argument("--output", required=True, help="Output directory")
+    parser.add_argument("--n_components", type=int, default=None, help="Number of components")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+    out_dir = Path(args.output) / "MFA"
+
+    df_active, quant_vars, qual_vars = prepare_active_dataset(args.input, out_dir)
+
+    model, rows = run_mfa(
+        df_active,
+        quant_vars,
+        qual_vars,
+        out_dir,
+        n_components=args.n_components,
+    )
+
+    export_mfa_results(model, rows, out_dir, quant_vars, qual_vars, df_active=df_active)
+    logging.info("MFA analysis complete")
+
+
+if __name__ == "__main__":
+    main()

--- a/phase4_pacmap.py
+++ b/phase4_pacmap.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Standalone PaCMAP analysis using functions from phase4v2."""
+
+import argparse
+import logging
+from pathlib import Path
+
+from phase4v2 import run_pacmap, export_pacmap_results
+from standalone_utils import prepare_active_dataset
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run PaCMAP only")
+    parser.add_argument("--input", required=True, help="Excel file")
+    parser.add_argument("--output", required=True, help="Output directory")
+    parser.add_argument("--n_components", type=int, default=2, help="Number of components")
+    parser.add_argument("--n_neighbors", type=int, default=None, help="Number of neighbors")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+    out_dir = Path(args.output) / "PaCMAP"
+
+    df_active, quant_vars, qual_vars = prepare_active_dataset(args.input, out_dir)
+
+    model, emb = run_pacmap(
+        df_active,
+        quant_vars,
+        qual_vars,
+        out_dir,
+        n_components=args.n_components,
+        n_neighbors=args.n_neighbors,
+    )
+
+    if model is not None:
+        export_pacmap_results(emb, df_active, out_dir)
+    logging.info("PaCMAP analysis complete")
+
+
+if __name__ == "__main__":
+    main()

--- a/phase4_pca.py
+++ b/phase4_pca.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Standalone PCA analysis using functions from phase4v2."""
+
+import argparse
+import logging
+from pathlib import Path
+
+from phase4v2 import run_pca, export_pca_results
+from standalone_utils import prepare_active_dataset
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run PCA only")
+    parser.add_argument("--input", required=True, help="Excel file")
+    parser.add_argument("--output", required=True, help="Output directory")
+    parser.add_argument("--n_components", type=int, default=None, help="Number of components")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+    out_dir = Path(args.output) / "PCA"
+
+    df_active, quant_vars, qual_vars = prepare_active_dataset(args.input, out_dir)
+
+    model, inertia, rows, cols, contrib = run_pca(
+        df_active,
+        quant_vars,
+        qual_vars,
+        out_dir,
+        n_components=args.n_components,
+    )
+
+    export_pca_results(model, inertia, rows, cols, out_dir, quant_vars, df_active=df_active)
+    logging.info("PCA analysis complete")
+
+
+if __name__ == "__main__":
+    main()

--- a/phase4_pcamix.py
+++ b/phase4_pcamix.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Standalone PCAmix analysis using functions from phase4v2."""
+
+import argparse
+import logging
+from pathlib import Path
+
+from phase4v2 import run_pcamix, export_pcamix_results
+from standalone_utils import prepare_active_dataset
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run PCAmix only")
+    parser.add_argument("--input", required=True, help="Excel file")
+    parser.add_argument("--output", required=True, help="Output directory")
+    parser.add_argument("--n_components", type=int, default=None, help="Number of components")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+    out_dir = Path(args.output) / "PCAmix"
+
+    df_active, quant_vars, qual_vars = prepare_active_dataset(args.input, out_dir)
+
+    model, inertia, rows, cols = run_pcamix(
+        df_active,
+        quant_vars,
+        qual_vars,
+        out_dir,
+        n_components=args.n_components,
+    )
+
+    export_pcamix_results(model, inertia, rows, cols, out_dir, quant_vars, qual_vars, df_active=df_active)
+    logging.info("PCAmix analysis complete")
+
+
+if __name__ == "__main__":
+    main()

--- a/phase4_phate.py
+++ b/phase4_phate.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Standalone PHATE analysis using functions from phase4v2."""
+
+import argparse
+import logging
+from pathlib import Path
+
+from phase4v2 import run_phate, export_phate_results
+from standalone_utils import prepare_active_dataset
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run PHATE only")
+    parser.add_argument("--input", required=True, help="Excel file")
+    parser.add_argument("--output", required=True, help="Output directory")
+    parser.add_argument("--n_components", type=int, default=2, help="Number of components")
+    parser.add_argument("--knn", type=int, default=None, help="Number of neighbors")
+    parser.add_argument("--t", default="auto", help="Diffusion steps")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+    out_dir = Path(args.output) / "PHATE"
+
+    df_active, quant_vars, qual_vars = prepare_active_dataset(args.input, out_dir)
+
+    op, emb = run_phate(
+        df_active,
+        quant_vars,
+        qual_vars,
+        out_dir,
+        n_components=args.n_components,
+        knn=args.knn,
+        t=args.t,
+    )
+
+    if op is not None:
+        export_phate_results(emb, df_active, out_dir)
+    logging.info("PHATE analysis complete")
+
+
+if __name__ == "__main__":
+    main()

--- a/phase4_tsne.py
+++ b/phase4_tsne.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Standalone t-SNE analysis using functions from phase4v2."""
+
+import argparse
+import logging
+from pathlib import Path
+
+from phase4v2 import run_famd, run_tsne, export_tsne_results
+from standalone_utils import prepare_active_dataset
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run t-SNE only (requires FAMD)")
+    parser.add_argument("--input", required=True, help="Excel file")
+    parser.add_argument("--output", required=True, help="Output directory")
+    parser.add_argument("--perplexity", type=int, default=None, help="t-SNE perplexity")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+    out_dir = Path(args.output) / "TSNE"
+
+    df_active, quant_vars, qual_vars = prepare_active_dataset(args.input, out_dir)
+
+    famd_model, inertia, rows, cols, contrib = run_famd(df_active, quant_vars, qual_vars)
+
+    tsne_model, tsne_df, metrics = run_tsne(
+        rows,
+        df_active,
+        out_dir,
+        perplexity=args.perplexity,
+    )
+
+    export_tsne_results(tsne_df, df_active, out_dir, metrics)
+    logging.info("t-SNE analysis complete")
+
+
+if __name__ == "__main__":
+    main()

--- a/phase4_umap.py
+++ b/phase4_umap.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Standalone UMAP analysis using functions from phase4v2."""
+
+import argparse
+import logging
+from pathlib import Path
+
+from phase4v2 import run_umap, export_umap_results
+from standalone_utils import prepare_active_dataset
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run UMAP only")
+    parser.add_argument("--input", required=True, help="Excel file")
+    parser.add_argument("--output", required=True, help="Output directory")
+    parser.add_argument("--n_components", type=int, default=2, help="Number of components")
+    parser.add_argument("--n_neighbors", type=int, default=None, help="Number of neighbors")
+    parser.add_argument("--min_dist", type=float, default=None, help="Minimum distance")
+    parser.add_argument("--metric", default="euclidean", help="UMAP distance metric")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+    out_dir = Path(args.output) / "UMAP"
+
+    df_active, quant_vars, qual_vars = prepare_active_dataset(args.input, out_dir)
+
+    model, emb = run_umap(
+        df_active,
+        quant_vars,
+        qual_vars,
+        out_dir,
+        n_neighbors=args.n_neighbors,
+        min_dist=args.min_dist,
+        n_components=args.n_components,
+        metric=args.metric,
+    )
+
+    export_umap_results(emb, df_active, out_dir)
+    logging.info("UMAP analysis complete")
+
+
+if __name__ == "__main__":
+    main()

--- a/standalone_utils.py
+++ b/standalone_utils.py
@@ -1,0 +1,44 @@
+import logging
+from pathlib import Path
+from typing import List, Tuple
+import pandas as pd
+
+from phase4v2 import (
+    load_data,
+    prepare_data,
+    select_variables,
+    sanity_check,
+    handle_missing_values,
+    segment_data,
+)
+
+
+def prepare_active_dataset(input_file: str, output_dir: Path) -> Tuple[pd.DataFrame, List[str], List[str]]:
+    """Load CRM data and return the cleaned active dataset.
+
+    Parameters
+    ----------
+    input_file : str
+        Path to the Excel file exported from Everwin.
+    output_dir : Path
+        Directory where segmentation figures will be saved.
+
+    Returns
+    -------
+    df_active : pd.DataFrame
+        Cleaned dataframe limited to the selected variables.
+    quant_vars : list of str
+        Names of quantitative variables kept for the analysis.
+    qual_vars : list of str
+        Names of qualitative variables kept for the analysis.
+    """
+    df_raw = load_data(input_file)
+    df_clean = prepare_data(df_raw)
+    df_active, quant_vars, qual_vars = select_variables(df_clean)
+    quant_vars, qual_vars = sanity_check(df_active, quant_vars, qual_vars)
+    df_active = df_active[quant_vars + qual_vars]
+    df_active = handle_missing_values(df_active, quant_vars, qual_vars)
+
+    # Generate simple segmentation reports
+    segment_data(df_active, qual_vars, output_dir)
+    return df_active, quant_vars, qual_vars


### PR DESCRIPTION
## Summary
- provide `standalone_utils.py` helper to prepare the dataset
- add standalone executables for PCA, MCA, MFA, PCAmix, UMAP, PaCMAP, PHATE and t-SNE

These scripts load the data, prepare it using shared utilities and run a single method using the existing functions from `phase4v2.py`.

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`