### PR TITLE
Add MFA fine tuning script

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,32 @@ python phase4_famd.py --input "D:\DATAPREDICT\DATAPREDICT 2024\Missions\Digora\e
 
 This mirrors the paths used when the original script was created and will
 generate figures and CSV results inside the specified output folder.
+
+## Fine tuning MFA
+
+The script `fine_tune_mfa.py` automates a small grid search over the number of
+components and optional group weights for a Multiple Factor Analysis. Provide a
+YAML configuration describing the groups and ranges:
+
+```yaml
+input_file: path/to/data.xlsx
+output_dir: phase4_output/fine_tuning_mfa
+group_defs:
+  Financier: ["Total recette actualisé", "Budget client estimé"]
+  Temporalité: ["duree_projet_jours", "taux_realisation"]
+mfa_params:
+  min_components: 2
+  max_components: 6
+  weights:
+    - null
+    - {Financier: 1.5, Temporalité: 1.0}
+```
+
+Run it with:
+
+```bash
+python fine_tune_mfa.py --config config_mfa.yaml
+```
+
+The script exports metrics for each configuration and saves the best model (by
+silhouette and Calinski–Harabasz indices) in the configured output directory.

--- a/fine_tune_mfa.py
+++ b/fine_tune_mfa.py
@@ -1,0 +1,97 @@
+import argparse
+import json
+import logging
+from pathlib import Path
+from time import time
+import yaml
+import pandas as pd
+from itertools import product
+from sklearn.cluster import KMeans
+from sklearn.metrics import silhouette_score, calinski_harabasz_score
+
+from standalone_utils import prepare_active_dataset
+from phase4v2 import run_mfa, export_mfa_results
+
+
+def load_config(path: Path) -> dict:
+    if path.suffix.lower() in {'.yaml', '.yml'}:
+        return yaml.safe_load(path.read_text())
+    return json.loads(path.read_text())
+
+
+def evaluate_embedding(emb: pd.DataFrame, k_range=range(2, 7)) -> tuple[float, float]:
+    best_sil = -1.0
+    best_ch = -1.0
+    for k in k_range:
+        labels = KMeans(n_clusters=k, random_state=0).fit_predict(emb.values)
+        sil = silhouette_score(emb.values, labels)
+        ch = calinski_harabasz_score(emb.values, labels)
+        if sil > best_sil:
+            best_sil = sil
+        if ch > best_ch:
+            best_ch = ch
+    return best_sil, best_ch
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Fine tune MFA")
+    p.add_argument("--config", required=True, help="YAML or JSON config file")
+    args = p.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+    cfg = load_config(Path(args.config))
+
+    input_file = cfg["input_file"]
+    out_dir = Path(cfg.get("output_dir", "phase4_output/fine_tuning_mfa"))
+    group_defs = cfg.get("group_defs")
+    mfa_cfg = cfg.get("mfa_params", {})
+    n_components_range = list(range(mfa_cfg.get("min_components", 2), mfa_cfg.get("max_components", 10) + 1))
+    weight_options = mfa_cfg.get("weights", [None])
+    n_iter = int(mfa_cfg.get("n_iter", 3))
+
+    df_active, quant_vars, qual_vars = prepare_active_dataset(input_file, out_dir)
+
+    results = []
+    best = None
+    best_metrics = (-1.0, -1.0)
+    for n_comp, weights in product(n_components_range, weight_options):
+        start = time()
+        model, rows = run_mfa(
+            df_active,
+            quant_vars,
+            qual_vars,
+            out_dir / f"mfa_{n_comp}",
+            n_components=n_comp,
+            groups=group_defs,
+            weights=weights,
+            n_iter=n_iter,
+        )
+        runtime = time() - start
+        inertia = sum(model.explained_inertia_)
+        sil, ch = evaluate_embedding(rows)
+        results.append({
+            "n_components": n_comp,
+            "weights": weights,
+            "runtime_s": runtime,
+            "cum_inertia": inertia,
+            "silhouette": sil,
+            "calinski": ch,
+        })
+        if inertia >= 0.8 and (sil > best_metrics[0] or ch > best_metrics[1]):
+            best_metrics = (sil, ch)
+            best = (model, rows, n_comp, weights)
+
+    pd.DataFrame(results).to_csv(out_dir / "mfa_grid_search.csv", index=False)
+
+    if best is None:
+        logging.warning("No configuration reached 80% inertia; keeping last one")
+        model, rows, _, _ = model, rows, n_comp, weights
+    else:
+        model, rows, n_comp, weights = best
+
+    export_mfa_results(model, rows, out_dir / "best", quant_vars, qual_vars, df_active=df_active)
+    logging.info("Best MFA with %d components", n_comp)
+
+
+if __name__ == "__main__":
+    main()

--- a/phase4v2.py
+++ b/phase4v2.py
@@ -666,6 +666,8 @@ def run_mfa(
         groups: Optional[Dict[str, Sequence[str]]] = None,
         optimize: bool = False,
         normalize: bool = True,
+        weights: Optional[Dict[str, float]] = None,
+        n_iter: int = 3,
 ) -> Tuple[prince.MFA, pd.DataFrame]:
     """Exécute une MFA sur le jeu de données mixte.
 
@@ -682,6 +684,10 @@ def run_mfa(
             automatiquement le nombre d'axes (90 % de variance cumulée).
         normalize: Active la normalisation par groupe pour équilibrer leur
             contribution.
+        weights: Pondération facultative ``{groupe: poids}`` appliquée après la
+            normalisation.
+        n_iter: Nombre d'itérations pour l'algorithme de l'implémentation
+            prince.
 
     Returns:
         - L’objet prince.MFA entraîné.
@@ -730,6 +736,19 @@ def run_mfa(
     # Combine numeric columns with the dummy-encoded qualitative variables
     df_mfa = pd.concat([df_active[quant_vars], df_dummies], axis=1)[used_cols]
 
+    if normalize:
+        from sklearn.preprocessing import StandardScaler
+        for g, cols in groups.items():
+            if not cols:
+                continue
+            scaler = StandardScaler()
+            df_mfa[cols] = scaler.fit_transform(df_mfa[cols])
+
+    if weights:
+        for g, w in weights.items():
+            if g in groups:
+                df_mfa[groups[g]] = df_mfa[groups[g]] * float(w)
+
     logger = logging.getLogger(__name__)
 
     n_comp = n_components
@@ -744,7 +763,7 @@ def run_mfa(
 
     n_comp = n_comp or 5
 
-    mfa = prince.MFA(n_components=n_comp, n_iter=3)
+    mfa = prince.MFA(n_components=n_comp, n_iter=n_iter)
     mfa = mfa.fit(df_mfa, groups=groups)
     mfa.df_encoded_ = df_mfa
     mfa.groups_input_ = groups


### PR DESCRIPTION
## Summary
- extend `run_mfa` with group normalization, optional weights and configurable `n_iter`
- provide new `fine_tune_mfa.py` script to grid-search MFA hyperparameters and evaluate clustering quality
- document the new script usage in `README`

## Testing
- `python -m py_compile phase4v2.py fine_tune_mfa.py`
- `pytest -q`