### PR TITLE
Add PHATE fine-tuning helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,30 @@ python phase4_famd.py --input "D:\DATAPREDICT\DATAPREDICT 2024\Missions\Digora\e
 
 This mirrors the paths used when the original script was created and will
 generate figures and CSV results inside the specified output folder.
+
+### Fine-tuning `phase4_famd_simple.py`
+
+The lightweight script `phase4_famd_simple.py` exposes a couple of options to
+automatically choose the number of components. Use `--optimize` together with
+`--rule` to specify the selection criterion (``variance``, ``kaiser`` or
+``elbow``). The variance rule accepts an additional `--variance_threshold`
+argument. Example:
+
+```bash
+python phase4_famd_simple.py --input export_everwin.xlsx \
+                            --output phase4_output \
+                            --optimize --rule variance --variance_threshold 0.9
+```
+
+## Fine-tuning PHATE on Phase 3 data
+
+The script `phase4_fine_tune_phate.py` demonstrates how to run PHATE on the cleaned CSV files produced by phase 3. Provide the multivariate and univariate datasets along with an output directory:
+
+```bash
+python phase4_fine_tune_phate.py --multi /path/to/phase3_cleaned_multivariate.csv \
+                                 --univ /path/to/phase3_cleaned_univ.csv \
+                                 --output /path/to/output_dir
+```
+
+The script handles basic preprocessing (dropping identifiers, imputing values, scaling numerical variables and one-hot encoding categories) before running PHATE. Coordinates and a scatter plot coloured by `Statut commercial` are written inside the output directory.
+

--- a/phase4_famd_simple.py
+++ b/phase4_famd_simple.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
-"""Standalone FAMD analysis using functions from phase4v2."""
+"""Standalone FAMD analysis with optional fine-tuning.
+
+This script loads the CRM Excel export, prepares the active dataset and runs
+FAMD using helper functions from :mod:`phase4v2`.  It exposes a few command
+line options to tune the analysis, notably the automatic selection of the
+number of components.
+"""
 
 import argparse
 import logging
@@ -13,7 +19,16 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Run FAMD only")
     parser.add_argument("--input", required=True, help="Excel file")
     parser.add_argument("--output", required=True, help="Output directory")
-    parser.add_argument("--n_components", type=int, default=None, help="Number of components")
+    parser.add_argument("--n_components", type=int, default=None,
+                        help="Number of components")
+    parser.add_argument("--optimize", action="store_true",
+                        help="Automatically pick the number of components")
+    parser.add_argument("--rule", choices=["variance", "kaiser", "elbow"],
+                        help="Selection rule when optimizing")
+    parser.add_argument("--variance_threshold", type=float, default=0.9,
+                        help="Variance threshold for the variance rule")
+    parser.add_argument("--weighting", choices=["balanced", "auto", "manual"],
+                        default="balanced", help="Variable weighting")
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
@@ -21,11 +36,19 @@ def main() -> None:
 
     df_active, quant_vars, qual_vars = prepare_active_dataset(args.input, out_dir)
 
+    famd_cfg = {
+        "weighting": args.weighting,
+        "n_components_rule": args.rule,
+        "variance_threshold": args.variance_threshold,
+    }
+
     famd, inertia, rows, cols, contrib = run_famd(
         df_active,
         quant_vars,
         qual_vars,
         n_components=args.n_components,
+        famd_cfg=famd_cfg,
+        optimize=args.optimize,
     )
 
     export_famd_results(

--- a/phase4_fine_tune_phate.py
+++ b/phase4_fine_tune_phate.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Fine-tuning PHATE on Phase 3 cleaned datasets.
+
+This script loads the cleaned CSV files produced at the end of phase 3,
+performs basic preprocessing (imputation, scaling, encoding) and runs the
+PHATE algorithm. The resulting embeddings and a simple scatter plot are
+saved in the chosen output directory.
+"""
+
+import argparse
+import os
+from pathlib import Path
+from typing import List
+
+import matplotlib.pyplot as plt
+import pandas as pd
+import numpy as np
+import seaborn as sns
+from sklearn.preprocessing import StandardScaler, OneHotEncoder
+import phate
+
+
+_DEF_DROP = {"id", "code", "client", "contact"}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Fine tune PHATE on Phase 3 data")
+    parser.add_argument("--multi", required=True, help="Cleaned multivariate CSV")
+    parser.add_argument("--univ", required=False, help="Cleaned univariate CSV")
+    parser.add_argument("--output", required=True, help="Output directory")
+    parser.add_argument("--knn", type=int, default=10, help="Number of neighbors")
+    parser.add_argument("--decay", type=int, default=20, help="Kernel decay")
+    parser.add_argument("--n_components", type=int, default=2, help="Dimensions")
+    parser.add_argument("--t", type=int, default=20, help="Diffusion steps")
+    return parser.parse_args()
+
+
+def preprocess(df: pd.DataFrame) -> tuple[pd.DataFrame, List[str], List[str], np.ndarray]:
+    drop_cols = [c for c in df.columns if any(p in c.lower() for p in _DEF_DROP) or "date" in c.lower()]
+    df = df.drop(columns=drop_cols, errors="ignore")
+
+    num_cols = df.select_dtypes(include=["number"]).columns.tolist()
+    cat_cols = [c for c in df.columns if c not in num_cols]
+
+    if num_cols:
+        df[num_cols] = df[num_cols].fillna(df[num_cols].median())
+    for c in cat_cols:
+        df[c] = df[c].fillna("Non renseigné")
+
+    scaler = StandardScaler()
+    X_num = scaler.fit_transform(df[num_cols]) if num_cols else np.empty((len(df), 0))
+
+    try:
+        enc = OneHotEncoder(drop="first", sparse_output=False, handle_unknown="ignore")
+    except TypeError:  # pragma: no cover - older scikit-learn
+        enc = OneHotEncoder(drop="first", sparse=False, handle_unknown="ignore")
+    X_cat = enc.fit_transform(df[cat_cols]) if cat_cols else np.empty((len(df), 0))
+
+    X = np.hstack([X_num, X_cat])
+    return df, num_cols, cat_cols, X
+
+
+def run_phate(X: np.ndarray, knn: int, decay: int, n_components: int, t: int) -> np.ndarray:
+    ph = phate.PHATE(
+        knn=knn,
+        decay=decay,
+        n_components=n_components,
+        t=t,
+        random_state=42,
+    )
+    return ph.fit_transform(X)
+
+
+def main() -> None:
+    args = parse_args()
+    out = Path(args.output)
+    out.mkdir(parents=True, exist_ok=True)
+
+    df_multi = pd.read_csv(args.multi)
+    if args.univ:
+        pd.read_csv(args.univ)  # loaded for completeness but not used further
+
+    df_multi, num_cols, cat_cols, X = preprocess(df_multi)
+    emb = run_phate(X, args.knn, args.decay, args.n_components, args.t)
+
+    cols = [f"PHATE{i+1}" for i in range(args.n_components)]
+    df_emb = pd.DataFrame(emb, columns=cols)
+    df_emb.to_csv(out / "phate_coordinates.csv", index=False)
+
+    if {"PHATE1", "PHATE2"}.issubset(df_emb.columns) and "Statut commercial" in df_multi.columns:
+        plot_df = df_emb.join(df_multi["Statut commercial"])
+        plt.figure(figsize=(8, 6))
+        sns.scatterplot(x="PHATE1", y="PHATE2", hue="Statut commercial", data=plot_df, palette="tab10")
+        plt.title("PHATE – Statut commercial")
+        plt.tight_layout()
+        plt.savefig(out / "phate_scatter_statut_commercial.png")
+        plt.close()
+
+    readme = out / "README.md"
+    with readme.open("w", encoding="utf-8") as fh:
+        fh.write("# Fine-tuning PHATE\n")
+        fh.write("Input files: ``{}``, ``{}``\n".format(args.multi, args.univ or "n/a"))
+        fh.write("\n")
+        fh.write("Hyperparameters:\n")
+        fh.write(f"- knn = {args.knn}\n")
+        fh.write(f"- decay = {args.decay}\n")
+        fh.write(f"- n_components = {args.n_components}\n")
+        fh.write(f"- t = {args.t}\n")
+        fh.write("\n")
+        fh.write("Run with:\n")
+        fh.write("```bash\n")
+        fh.write(
+            f"python {Path(__file__).name} --multi '{args.multi}' --univ '{args.univ or ''}' --output '{args.output}'\n"
+        )
+        fh.write("```\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `phase4_fine_tune_phate.py` script that loads Phase 3 CSV exports and runs PHATE
- document usage of the new script in README
- add fine-tuning options to `phase4_famd_simple.py` and update docs

## Testing
- `python test_run_famd.py`
- `python test_run_pacmap.py` (reported missing pacmap module)
- `python test_run_pcamix.py`
- `python test_run_phate.py`
