### PR TITLE
Handle CSV input in load_data

### DIFF
--- a/fine_tune_famd.py
+++ b/fine_tune_famd.py
@@ -9,8 +9,8 @@ from pathlib import Path
 from phase4v2 import run_famd, export_famd_results
 from standalone_utils import prepare_active_dataset
 
-DATA_PATH = Path("/mnt/data/phase3_cleaned_multivariate.csv")
-OUTPUT_DIR = Path("/mnt/data/phase4_output/fine_tuning_famd")
+DATA_PATH = Path("phase3_output/phase3_cleaned_multivariate.csv")
+OUTPUT_DIR = Path("phase4_output/fine_tuning_famd")
 
 
 def main() -> None:

--- a/fine_tune_pca.py
+++ b/fine_tune_pca.py
@@ -16,8 +16,8 @@ from sklearn.metrics import silhouette_score
 
 from phase4v2 import plot_correlation_circle
 
-INPUT_FILE = r"D:\DATAPREDICT\DATAPREDICT 2024\Missions\Digora\phase3_output\phase3_cleaned_multivariate.csv"
-OUTPUT_DIR = Path(r"D:\DATAPREDICT\DATAPREDICT 2024\Missions\Digora\phase4_output\fine_tuning_pca")
+INPUT_FILE = "phase3_output/phase3_cleaned_multivariate.csv"
+OUTPUT_DIR = Path("phase4_output/fine_tuning_pca")
 
 CANDIDATE_QUANT = [
     "Total recette actualisé",

--- a/fine_tune_pcamix.py
+++ b/fine_tune_pcamix.py
@@ -9,8 +9,8 @@ from pathlib import Path
 from phase4v2 import run_pcamix, export_pcamix_results
 from standalone_utils import prepare_active_dataset
 
-DATA_PATH = Path("/mnt/data/phase3_cleaned_multivariate.csv")
-OUTPUT_DIR = Path("/mnt/data/phase4_output/fine_tuning_pcamix")
+DATA_PATH = Path("phase3_output/phase3_cleaned_multivariate.csv")
+OUTPUT_DIR = Path("phase4_output/fine_tuning_pcamix")
 
 
 def main() -> None:

--- a/fine_tune_tsne.py
+++ b/fine_tune_tsne.py
@@ -28,8 +28,8 @@ from sklearn.metrics import silhouette_score
 from sklearn.preprocessing import OneHotEncoder, StandardScaler
 
 
-DEFAULT_INPUT = "/mnt/data/phase3_cleaned_multivariate.csv"
-DEFAULT_OUTPUT = "/mnt/data/phase4_output/fine_tuning_tsne"
+DEFAULT_INPUT = "phase3_output/phase3_cleaned_multivariate.csv"
+DEFAULT_OUTPUT = "phase4_output/fine_tuning_tsne"
 
 
 def load_preprocess(csv_path: str) -> tuple[pd.DataFrame, np.ndarray]:

--- a/fine_tuning_mca.py
+++ b/fine_tuning_mca.py
@@ -14,12 +14,12 @@ from phase4v2 import plot_correlation_circle
 # ----------------------------------------------------------------------
 # Configuration paths
 INPUT_FILES = [
-    r"D:\\DATAPREDICT\\DATAPREDICT 2024\\Missions\\Digora\\phase1_output\\phase1_categorical_cleaned.csv",
-    r"D:\\DATAPREDICT\\DATAPREDICT 2024\\Missions\\Digora\\phase2_output\\phase2_categorical_overview.csv",
-    r"D:\\DATAPREDICT\\DATAPREDICT 2024\\Missions\\Digora\\phase3_output\\phase3_cleaned_multivariate.csv",
+    "phase1_output/export_phase1_cleaned.csv",
+    "phase2_output/phase2_categorical_overview.csv",
+    "phase3_output/phase3_cleaned_multivariate.csv",
 ]
 
-OUTPUT_ROOT = Path(r"D:\\DATAPREDICT\\DATAPREDICT 2024\\Missions\\Digora\\phase4_output\\fine_tuning_mca")
+OUTPUT_ROOT = Path("phase4_output/fine_tuning_mca")
 FIG_DIR = OUTPUT_ROOT / "figures"
 CSV_DIR = OUTPUT_ROOT / "csv"
 

--- a/fine_tuning_umap.py
+++ b/fine_tuning_umap.py
@@ -18,9 +18,9 @@ from sklearn.metrics import silhouette_score
 import umap
 
 
-DATA_PATH = Path("/mnt/data/phase3_cleaned_multivariate.csv")
-DICT_PATH = Path("/mnt/data/phase3_data_dictionary.xlsx")
-OUTPUT_DIR = Path("/mnt/data/phase4_output/fine_tuning_umap")
+DATA_PATH = Path("phase3_output/phase3_cleaned_multivariate.csv")
+DICT_PATH = Path("phase3_output/phase3_data_dictionary.xlsx")
+OUTPUT_DIR = Path("phase4_output/fine_tuning_umap")
 RANDOM_STATE = 42
 
 

--- a/pacmap_fine_tune.py
+++ b/pacmap_fine_tune.py
@@ -20,8 +20,8 @@ import pacmap
 from phase4v2 import select_variables, handle_missing_values
 
 
-INPUT_FILE = Path(r"D:\DATAPREDICT\DATAPREDICT 2024\Missions\Digora\phase3_output\phase3_cleaned_multivariate.csv")
-OUTPUT_DIR = Path(r"D:\DATAPREDICT\DATAPREDICT 2024\Missions\Digora\phase4_output\fine_tuning_pacmap")
+INPUT_FILE = Path("phase3_output/phase3_cleaned_multivariate.csv")
+OUTPUT_DIR = Path("phase4_output/fine_tuning_pacmap")
 
 
 def prepare_dataset(path: Path) -> tuple[pd.DataFrame, list[str], list[str], pd.Series]:

--- a/phase4v2.py
+++ b/phase4v2.py
@@ -201,14 +201,15 @@ def plot_na_dashboard(na_df: pd.DataFrame, output_path: Path):
 
 
 def load_data(file_path: str) -> pd.DataFrame:
-    """
-    Charge les données CRM brutes depuis un fichier Excel
-    et réalise quelques contrôles de base.
+    """Charge les données CRM brutes depuis un fichier.
+
+    Le fichier peut être au format Excel (``.xls`` ou ``.xlsx``) ou CSV.
+    Quelques contrôles de base sont effectués après la lecture.
 
     Parameters
     ----------
     file_path : str
-        Chemin vers le fichier Excel d’export Everwin (ex. "export_everwin (19).xlsx").
+        Chemin vers le fichier d'export Everwin.
 
     Returns
     -------
@@ -223,16 +224,23 @@ def load_data(file_path: str) -> pd.DataFrame:
         Si la lecture échoue pour une autre raison.
     """
     logger = logging.getLogger(__name__)
-    # Lecture du fichier Excel
+    path = Path(file_path)
     try:
-        df = pd.read_excel(file_path)
-        logger.info(f"Données chargées : {df.shape[0]} lignes × {df.shape[1]} colonnes")
-    except FileNotFoundError as fnf_err:
-        logger.error(f"Fichier introuvable : {file_path}")
+        if path.suffix.lower() == ".csv":
+            df = pd.read_csv(file_path)
+        else:
+            df = pd.read_excel(file_path, engine="openpyxl")
+        logger.info(
+            "Données chargées : %s lignes × %s colonnes",
+            df.shape[0],
+            df.shape[1],
+        )
+    except FileNotFoundError:
+        logger.error("Fichier introuvable : %s", file_path)
         raise
     except Exception as e:
-        logger.error(f"Erreur lors du chargement de '{file_path}' : {e}")
-        raise ValueError(f"Impossible de charger le fichier Excel : {e}")
+        logger.error("Erreur lors du chargement de '%s' : %s", file_path, e)
+        raise ValueError(f"Impossible de charger le fichier : {e}") from e
 
     # Vérification rapide des colonnes
     logger.debug(f"Noms de colonnes avant nettoyage : {list(df.columns)}")


### PR DESCRIPTION
## Summary
- allow CSV files in `load_data`
- specify `openpyxl` engine for Excel files
- use local data paths in all fine-tuning scripts
- rebuild `run_all_fine_tunes.py` with default arguments for each script

## Testing
- `python -m py_compile fine_tune_famd.py fine_tune_pcamix.py fine_tune_pca.py pacmap_fine_tune.py fine_tuning_mca.py fine_tuning_umap.py fine_tune_tsne.py run_all_fine_tunes.py fine_tune_mfa.py phase4_fine_tune_phate.py`
- `python -m py_compile phase4v2.py run_all_fine_tunes.py`
- `python test_run_famd.py`
- `python test_run_pacmap.py`
- `python test_run_pcamix.py`
- `python test_run_phate.py`
