### PR TITLE
Fix fine tuning scripts and parallel launcher

### DIFF
--- a/fine_tune_pca.py
+++ b/fine_tune_pca.py
@@ -59,7 +59,10 @@ def run_pca_grid(X: np.ndarray, columns: list[str]):
     contrib_rows = []
     sil_rows = []
     config_id = 0
+    n_features = X.shape[1]
     for n_comp, solver, whiten in itertools.product(N_COMPONENTS, SVD_SOLVERS, WHITEN_OPTIONS):
+        if n_comp > n_features:
+            continue
         logging.info("PCA n_components=%d solver=%s whiten=%s", n_comp, solver, whiten)
         pca = PCA(n_components=n_comp, svd_solver=solver, whiten=whiten, random_state=0)
         X_pca = pca.fit_transform(X)

--- a/fine_tune_tsne.py
+++ b/fine_tune_tsne.py
@@ -46,7 +46,10 @@ def load_preprocess(csv_path: str) -> tuple[pd.DataFrame, np.ndarray]:
     scaler = StandardScaler()
     X_num = scaler.fit_transform(df_num)
 
-    encoder = OneHotEncoder(handle_unknown="ignore", sparse=False)
+    try:
+        encoder = OneHotEncoder(handle_unknown="ignore", sparse_output=False)
+    except TypeError:  # older scikit-learn
+        encoder = OneHotEncoder(handle_unknown="ignore", sparse=False)
     X_cat = encoder.fit_transform(df_cat)
 
     X_all = np.hstack([X_num, X_cat])

--- a/fine_tuning_mca.py
+++ b/fine_tuning_mca.py
@@ -260,7 +260,7 @@ def main() -> None:
                 fig_paths.append(plot_scree(inertia, base))
                 fig_paths.append(plot_correlation(cols, base, ("F1", "F2")))
                 if "F3" in cols.columns:
-                    fig_paths.append(plot_correlation(cols.rename(columns={"F3": "F2"}), base, ("F1", "F3")))
+                    fig_paths.append(plot_correlation(cols, base, ("F1", "F3")))
                 indiv2d, indiv3d = plot_individuals(rows, df, base)
                 mod, mod_zoom = plot_modalities(cols, base)
                 fig_paths.extend([indiv2d, indiv3d, mod, mod_zoom])

--- a/pacmap_fine_tune.py
+++ b/pacmap_fine_tune.py
@@ -96,14 +96,24 @@ def main() -> None:
         param_grid["init"],
     ):
         start = time.time()
-        model = pacmap.PaCMAP(
-            n_components=nc,
-            n_neighbors=nn,
-            MN_ratio=mn,
-            FP_ratio=2.0,
-            init=ini,
-            random_state=42,
-        )
+        try:
+            model = pacmap.PaCMAP(
+                n_components=nc,
+                n_neighbors=nn,
+                MN_ratio=mn,
+                FP_ratio=2.0,
+                initialization=ini,
+                random_state=42,
+            )
+        except TypeError:  # older pacmap
+            model = pacmap.PaCMAP(
+                n_components=nc,
+                n_neighbors=nn,
+                MN_ratio=mn,
+                FP_ratio=2.0,
+                init=ini,
+                random_state=42,
+            )
         embedding = model.fit_transform(X)
         runtime = time.time() - start
 
@@ -145,14 +155,24 @@ def main() -> None:
         nc = int(row["n_components"])
         ini = row["init"]
 
-        model = pacmap.PaCMAP(
-            n_components=nc,
-            n_neighbors=nn,
-            MN_ratio=mn,
-            FP_ratio=2.0,
-            init=ini,
-            random_state=42,
-        )
+        try:
+            model = pacmap.PaCMAP(
+                n_components=nc,
+                n_neighbors=nn,
+                MN_ratio=mn,
+                FP_ratio=2.0,
+                initialization=ini,
+                random_state=42,
+            )
+        except TypeError:  # older pacmap
+            model = pacmap.PaCMAP(
+                n_components=nc,
+                n_neighbors=nn,
+                MN_ratio=mn,
+                FP_ratio=2.0,
+                init=ini,
+                random_state=42,
+            )
         embedding = model.fit_transform(X)
 
         # Save coordinates

--- a/phase4_fine_tune_phate.py
+++ b/phase4_fine_tune_phate.py
@@ -45,6 +45,8 @@ def preprocess(df: pd.DataFrame) -> tuple[pd.DataFrame, List[str], List[str], np
     if num_cols:
         df[num_cols] = df[num_cols].fillna(df[num_cols].median())
     for c in cat_cols:
+        if df[c].dtype == bool:
+            df[c] = df[c].astype(str)
         df[c] = df[c].fillna("Non renseigné")
 
     scaler = StandardScaler()

--- a/run_fine_tuning_parallel.py
+++ b/run_fine_tuning_parallel.py
@@ -1,0 +1,101 @@
+import sys
+import os
+import subprocess
+from pathlib import Path
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+BASE_DIR = Path(r"D:\DATAPREDICT\DATAPREDICT 2024\Missions\Digora")
+PHASE1_CSV = BASE_DIR / "phase1_output" / "export_phase1_cleaned.csv"
+PHASE2_CSV = BASE_DIR / "phase2_output" / "phase2_business_variables.csv"
+PHASE3_MULTI = BASE_DIR / "phase3_output" / "phase3_cleaned_multivariate.csv"
+PHASE3_UNIV = BASE_DIR / "phase3_output" / "phase3_cleaned_univ.csv"
+PHASE4_DIR = BASE_DIR / "phase4_output"
+
+SCRIPTS = [
+    (
+        "fine_tune_famd.py",
+        ["--input", PHASE3_MULTI, "--output", PHASE4_DIR / "fine_tune_famd"],
+    ),
+    (
+        "fine_tuning_mca.py",
+        [
+            "--phase1",
+            PHASE1_CSV,
+            "--phase2",
+            PHASE2_CSV,
+            "--phase3",
+            PHASE3_MULTI,
+            "--output",
+            PHASE4_DIR / "fine_tune_mca",
+        ],
+    ),
+    (
+        "fine_tune_mfa.py",
+        ["--input", PHASE3_MULTI, "--output", PHASE4_DIR / "fine_tune_mfa"],
+    ),
+    (
+        "pacmap_fine_tune.py",
+        ["--input", PHASE3_MULTI, "--output", PHASE4_DIR / "fine_tune_pacmap"],
+    ),
+    (
+        "fine_tune_pca.py",
+        ["--input", PHASE3_MULTI, "--output", PHASE4_DIR / "fine_tune_pca"],
+    ),
+    (
+        "fine_tune_pcamix.py",
+        ["--input", PHASE3_MULTI, "--output", PHASE4_DIR / "fine_tune_pcamix"],
+    ),
+    (
+        "phase4_fine_tune_phate.py",
+        [
+            "--multi",
+            PHASE3_MULTI,
+            "--univ",
+            PHASE3_UNIV,
+            "--output",
+            PHASE4_DIR / "fine_tune_phate",
+        ],
+    ),
+    (
+        "fine_tune_tsne.py",
+        ["--input", PHASE3_MULTI, "--output", PHASE4_DIR / "fine_tune_tsne"],
+    ),
+    (
+        "fine_tuning_umap.py",
+        ["--input", PHASE3_MULTI, "--output", PHASE4_DIR / "fine_tune_umap"],
+    ),
+]
+
+
+def run_script(script: str, args: list[Path | str]) -> int:
+    """Run a fine-tuning script and return its exit code."""
+    cmd = [sys.executable, str(Path(__file__).parent / script)]
+    cmd += [str(a) for a in args]
+    env = os.environ.copy()
+    env.setdefault("OMP_NUM_THREADS", "1")
+    result = subprocess.run(cmd, env=env)
+    return result.returncode
+
+
+def main() -> None:
+    max_workers = min(len(SCRIPTS), os.cpu_count() or 1)
+    failed: list[str] = []
+    with ThreadPoolExecutor(max_workers=max_workers) as exe:
+        future_to_script = {exe.submit(run_script, s, a): s for s, a in SCRIPTS}
+        for future in as_completed(future_to_script):
+            script = future_to_script[future]
+            try:
+                ret = future.result()
+            except Exception:
+                ret = 1
+            if ret != 0:
+                failed.append(script)
+
+    if failed:
+        print("Some scripts failed:", ", ".join(failed))
+    else:
+        print("All fine-tuning scripts completed successfully")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- adjust parallel launcher to use ThreadPool for concurrent execution
- update OneHotEncoder usage for compatibility
- robustify PHATE preprocessing for boolean categories
- handle PaCMAP API changes
- fix MCA and PCA fine tuning edge cases

## Testing
- `python -m py_compile run_fine_tuning_parallel.py fine_tune_tsne.py phase4_fine_tune_phate.py pacmap_fine_tune.py fine_tuning_mca.py fine_tune_pca.py`
