### PR TITLE
Add parallel launcher improvements and bug fixes

### DIFF
--- a/fine_tune_pca.py
+++ b/fine_tune_pca.py
@@ -60,6 +60,8 @@ def run_pca_grid(X: np.ndarray, columns: list[str]):
     sil_rows = []
     config_id = 0
     for n_comp, solver, whiten in itertools.product(N_COMPONENTS, SVD_SOLVERS, WHITEN_OPTIONS):
+        if n_comp > min(X.shape[0], X.shape[1]):
+            continue
         logging.info("PCA n_components=%d solver=%s whiten=%s", n_comp, solver, whiten)
         pca = PCA(n_components=n_comp, svd_solver=solver, whiten=whiten, random_state=0)
         X_pca = pca.fit_transform(X)

--- a/fine_tune_tsne.py
+++ b/fine_tune_tsne.py
@@ -46,7 +46,10 @@ def load_preprocess(csv_path: str) -> tuple[pd.DataFrame, np.ndarray]:
     scaler = StandardScaler()
     X_num = scaler.fit_transform(df_num)
 
-    encoder = OneHotEncoder(handle_unknown="ignore", sparse=False)
+    try:
+        encoder = OneHotEncoder(handle_unknown="ignore", sparse_output=False)
+    except TypeError:  # for older scikit-learn
+        encoder = OneHotEncoder(handle_unknown="ignore", sparse=False)
     X_cat = encoder.fit_transform(df_cat)
 
     X_all = np.hstack([X_num, X_cat])

--- a/fine_tuning_mca.py
+++ b/fine_tuning_mca.py
@@ -260,7 +260,13 @@ def main() -> None:
                 fig_paths.append(plot_scree(inertia, base))
                 fig_paths.append(plot_correlation(cols, base, ("F1", "F2")))
                 if "F3" in cols.columns:
-                    fig_paths.append(plot_correlation(cols.rename(columns={"F3": "F2"}), base, ("F1", "F3")))
+                    fig_paths.append(
+                        plot_correlation(
+                            cols.rename(columns={"F3": "F2"}),
+                            base,
+                            ("F1", "F2"),
+                        )
+                    )
                 indiv2d, indiv3d = plot_individuals(rows, df, base)
                 mod, mod_zoom = plot_modalities(cols, base)
                 fig_paths.extend([indiv2d, indiv3d, mod, mod_zoom])

--- a/fine_tuning_umap.py
+++ b/fine_tuning_umap.py
@@ -27,7 +27,7 @@ def parse_args() -> argparse.Namespace:
 
 DATA_PATH = Path()
 OUTPUT_DIR = Path()
-RANDOM_STATE = 42
+RANDOM_STATE = None
 
 
 def setup_logger() -> logging.Logger:

--- a/pacmap_fine_tune.py
+++ b/pacmap_fine_tune.py
@@ -96,14 +96,23 @@ def main() -> None:
         param_grid["init"],
     ):
         start = time.time()
-        model = pacmap.PaCMAP(
-            n_components=nc,
-            n_neighbors=nn,
-            MN_ratio=mn,
-            FP_ratio=2.0,
-            init=ini,
-            random_state=42,
-        )
+        try:
+            model = pacmap.PaCMAP(
+                n_components=nc,
+                n_neighbors=nn,
+                MN_ratio=mn,
+                FP_ratio=2.0,
+                init=ini,
+                random_state=42,
+            )
+        except TypeError:
+            model = pacmap.PaCMAP(
+                n_components=nc,
+                n_neighbors=nn,
+                MN_ratio=mn,
+                FP_ratio=2.0,
+                random_state=42,
+            )
         embedding = model.fit_transform(X)
         runtime = time.time() - start
 
@@ -145,14 +154,23 @@ def main() -> None:
         nc = int(row["n_components"])
         ini = row["init"]
 
-        model = pacmap.PaCMAP(
-            n_components=nc,
-            n_neighbors=nn,
-            MN_ratio=mn,
-            FP_ratio=2.0,
-            init=ini,
-            random_state=42,
-        )
+        try:
+            model = pacmap.PaCMAP(
+                n_components=nc,
+                n_neighbors=nn,
+                MN_ratio=mn,
+                FP_ratio=2.0,
+                init=ini,
+                random_state=42,
+            )
+        except TypeError:
+            model = pacmap.PaCMAP(
+                n_components=nc,
+                n_neighbors=nn,
+                MN_ratio=mn,
+                FP_ratio=2.0,
+                random_state=42,
+            )
         embedding = model.fit_transform(X)
 
         # Save coordinates

--- a/phase4_fine_tune_phate.py
+++ b/phase4_fine_tune_phate.py
@@ -46,6 +46,8 @@ def preprocess(df: pd.DataFrame) -> tuple[pd.DataFrame, List[str], List[str], np
         df[num_cols] = df[num_cols].fillna(df[num_cols].median())
     for c in cat_cols:
         df[c] = df[c].fillna("Non renseigné")
+        if df[c].dtype == bool:
+            df[c] = df[c].astype(str)
 
     scaler = StandardScaler()
     X_num = scaler.fit_transform(df[num_cols]) if num_cols else np.empty((len(df), 0))

--- a/run_fine_tuning_parallel.py
+++ b/run_fine_tuning_parallel.py
@@ -1,0 +1,131 @@
+"""Launch all phase 4 fine tuning scripts in parallel.
+
+Each script is executed with predefined paths. If the output directory
+already contains files it is skipped to avoid reprocessing.
+An ``OMP_NUM_THREADS`` value of ``1`` is set for each process so that
+multiple jobs can fully utilise the available CPU cores.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import subprocess
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+
+BASE_DIR = Path(r"D:\DATAPREDICT\DATAPREDICT 2024\Missions\Digora")
+PHASE1_CSV = BASE_DIR / "phase1_output" / "export_phase1_cleaned.csv"
+PHASE2_CSV = BASE_DIR / "phase2_output" / "phase2_business_variables.csv"
+PHASE3_MULTI = BASE_DIR / "phase3_output" / "phase3_cleaned_multivariate.csv"
+PHASE3_UNIV = BASE_DIR / "phase3_output" / "phase3_cleaned_univ.csv"
+PHASE4_DIR = BASE_DIR / "phase4_output"
+
+
+class Job:
+    def __init__(self, script: str, args: list[Path | str], out_dir: Path) -> None:
+        self.script = script
+        self.args = args
+        self.out_dir = out_dir
+
+    def already_done(self) -> bool:
+        return self.out_dir.exists() and any(self.out_dir.iterdir())
+
+
+JOBS: list[Job] = [
+    Job(
+        "fine_tune_famd.py",
+        ["--input", PHASE3_MULTI, "--output", PHASE4_DIR / "fine_tune_famd"],
+        PHASE4_DIR / "fine_tune_famd",
+    ),
+    Job(
+        "fine_tuning_mca.py",
+        [
+            "--phase1",
+            PHASE1_CSV,
+            "--phase2",
+            PHASE2_CSV,
+            "--phase3",
+            PHASE3_MULTI,
+            "--output",
+            PHASE4_DIR / "fine_tune_mca",
+        ],
+        PHASE4_DIR / "fine_tune_mca",
+    ),
+    Job(
+        "fine_tune_mfa.py",
+        ["--input", PHASE3_MULTI, "--output", PHASE4_DIR / "fine_tune_mfa"],
+        PHASE4_DIR / "fine_tune_mfa",
+    ),
+    Job(
+        "pacmap_fine_tune.py",
+        ["--input", PHASE3_MULTI, "--output", PHASE4_DIR / "fine_tune_pacmap"],
+        PHASE4_DIR / "fine_tune_pacmap",
+    ),
+    Job(
+        "fine_tune_pca.py",
+        ["--input", PHASE3_MULTI, "--output", PHASE4_DIR / "fine_tune_pca"],
+        PHASE4_DIR / "fine_tune_pca",
+    ),
+    Job(
+        "fine_tune_pcamix.py",
+        ["--input", PHASE3_MULTI, "--output", PHASE4_DIR / "fine_tune_pcamix"],
+        PHASE4_DIR / "fine_tune_pcamix",
+    ),
+    Job(
+        "phase4_fine_tune_phate.py",
+        [
+            "--multi",
+            PHASE3_MULTI,
+            "--univ",
+            PHASE3_UNIV,
+            "--output",
+            PHASE4_DIR / "fine_tune_phate",
+        ],
+        PHASE4_DIR / "fine_tune_phate",
+    ),
+    Job(
+        "fine_tune_tsne.py",
+        ["--input", PHASE3_MULTI, "--output", PHASE4_DIR / "fine_tune_tsne"],
+        PHASE4_DIR / "fine_tune_tsne",
+    ),
+    Job(
+        "fine_tuning_umap.py",
+        ["--input", PHASE3_MULTI, "--output", PHASE4_DIR / "fine_tune_umap"],
+        PHASE4_DIR / "fine_tune_umap",
+    ),
+]
+
+
+def run_job(job: Job) -> tuple[str, int]:
+    if job.already_done():
+        return job.script, 0
+
+    cmd = [sys.executable, str(Path(__file__).parent / job.script)]
+    cmd += [str(a) for a in job.args]
+    env = os.environ.copy()
+    env.setdefault("OMP_NUM_THREADS", "1")
+    proc = subprocess.run(cmd, env=env)
+    return job.script, proc.returncode
+
+
+def main() -> None:
+    max_workers = min(os.cpu_count() or 1, len(JOBS))
+    failed: list[str] = []
+    with ThreadPoolExecutor(max_workers=max_workers) as exe:
+        futures = {exe.submit(run_job, job): job for job in JOBS}
+        for fut in as_completed(futures):
+            script, ret = fut.result()
+            if ret != 0:
+                failed.append(script)
+
+    if failed:
+        print("Some scripts failed:", ", ".join(failed))
+    else:
+        print("All fine-tuning scripts completed or were skipped")
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- add ThreadPool-based launcher that skips existing outputs and sets `OMP_NUM_THREADS`
- handle newer scikit-learn API in t-SNE and PHATE preprocessing
- support PaCMAP without `init` parameter
- avoid MCA F3 plotting error
- skip invalid PCA configurations and allow full parallelism in UMAP

## Testing
- `python -m py_compile run_fine_tuning_parallel.py fine_tune_tsne.py phase4_fine_tune_phate.py pacmap_fine_tune.py fine_tuning_mca.py fine_tune_pca.py fine_tuning_umap.py`