### PR TITLE
Add skipping logic and fix fine tuning scripts

### DIFF
--- a/fine_tune_pca.py
+++ b/fine_tune_pca.py
@@ -62,7 +62,11 @@ def run_pca_grid(X: np.ndarray, columns: list[str]):
     for n_comp, solver, whiten in itertools.product(N_COMPONENTS, SVD_SOLVERS, WHITEN_OPTIONS):
         logging.info("PCA n_components=%d solver=%s whiten=%s", n_comp, solver, whiten)
         pca = PCA(n_components=n_comp, svd_solver=solver, whiten=whiten, random_state=0)
-        X_pca = pca.fit_transform(X)
+        try:
+            X_pca = pca.fit_transform(X)
+        except ValueError:
+            logging.warning("Skipping n_components=%d with solver=%s", n_comp, solver)
+            continue
 
         cum_var = np.cumsum(pca.explained_variance_ratio_)
         for i, (var_ratio, sv) in enumerate(zip(pca.explained_variance_ratio_, pca.singular_values_), 1):

--- a/fine_tune_tsne.py
+++ b/fine_tune_tsne.py
@@ -40,13 +40,16 @@ def load_preprocess(csv_path: str) -> tuple[pd.DataFrame, np.ndarray]:
 
     # Imputation
     df_num = df[num_cols].fillna(df[num_cols].mean())
-    df_cat = df[cat_cols].fillna("unknown")
+    df_cat = df[cat_cols].astype(str).fillna("unknown")
 
     # Encoding / scaling
     scaler = StandardScaler()
     X_num = scaler.fit_transform(df_num)
 
-    encoder = OneHotEncoder(handle_unknown="ignore", sparse=False)
+    try:
+        encoder = OneHotEncoder(handle_unknown="ignore", sparse_output=False)
+    except TypeError:  # older scikit-learn
+        encoder = OneHotEncoder(handle_unknown="ignore", sparse=False)
     X_cat = encoder.fit_transform(df_cat)
 
     X_all = np.hstack([X_num, X_cat])

--- a/fine_tuning_umap.py
+++ b/fine_tuning_umap.py
@@ -27,7 +27,7 @@ def parse_args() -> argparse.Namespace:
 
 DATA_PATH = Path()
 OUTPUT_DIR = Path()
-RANDOM_STATE = 42
+RANDOM_STATE = None
 
 
 def setup_logger() -> logging.Logger:

--- a/pacmap_fine_tune.py
+++ b/pacmap_fine_tune.py
@@ -17,6 +17,12 @@ from sklearn.preprocessing import OneHotEncoder, StandardScaler
 
 import pacmap
 
+try:
+    pacmap.PaCMAP(init="pca")
+    _PACMAP_HAS_INIT = True
+except TypeError:  # pragma: no cover - older pacmap
+    _PACMAP_HAS_INIT = False
+
 # Import helper functions for variable selection and missing value handling
 from phase4v2 import select_variables, handle_missing_values
 
@@ -86,24 +92,21 @@ def main() -> None:
         "n_neighbors": [5, 15, 30, 50],
         "MN_ratio": [0.5, 1.0, 2.0],
         "n_components": [2, 3],
-        "init": ["pca", "random"],
     }
+    if _PACMAP_HAS_INIT:
+        param_grid["init"] = ["pca", "random"]
 
-    for nn, mn, nc, ini in itertools.product(
-        param_grid["n_neighbors"],
-        param_grid["MN_ratio"],
-        param_grid["n_components"],
-        param_grid["init"],
-    ):
+    iterables = [param_grid["n_neighbors"], param_grid["MN_ratio"], param_grid["n_components"]]
+    if _PACMAP_HAS_INIT:
+        iterables.append(param_grid["init"])
+    for combo in itertools.product(*iterables):
+        nn, mn, nc = combo[:3]
+        ini = combo[3] if _PACMAP_HAS_INIT else "pca"
         start = time.time()
-        model = pacmap.PaCMAP(
-            n_components=nc,
-            n_neighbors=nn,
-            MN_ratio=mn,
-            FP_ratio=2.0,
-            init=ini,
-            random_state=42,
-        )
+        kwargs = dict(n_components=nc, n_neighbors=nn, MN_ratio=mn, FP_ratio=2.0, random_state=42)
+        if _PACMAP_HAS_INIT:
+            kwargs["init"] = ini
+        model = pacmap.PaCMAP(**kwargs)
         embedding = model.fit_transform(X)
         runtime = time.time() - start
 

--- a/phase4_fine_tune_phate.py
+++ b/phase4_fine_tune_phate.py
@@ -46,6 +46,7 @@ def preprocess(df: pd.DataFrame) -> tuple[pd.DataFrame, List[str], List[str], np
         df[num_cols] = df[num_cols].fillna(df[num_cols].median())
     for c in cat_cols:
         df[c] = df[c].fillna("Non renseigné")
+    df[cat_cols] = df[cat_cols].astype(str)
 
     scaler = StandardScaler()
     X_num = scaler.fit_transform(df[num_cols]) if num_cols else np.empty((len(df), 0))

--- a/run_fine_tuning_parallel.py
+++ b/run_fine_tuning_parallel.py
@@ -1,0 +1,114 @@
+import sys
+import os
+import subprocess
+from pathlib import Path
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+BASE_DIR = Path(r"D:\DATAPREDICT\DATAPREDICT 2024\Missions\Digora")
+PHASE1_CSV = BASE_DIR / "phase1_output" / "export_phase1_cleaned.csv"
+PHASE2_CSV = BASE_DIR / "phase2_output" / "phase2_business_variables.csv"
+PHASE3_MULTI = BASE_DIR / "phase3_output" / "phase3_cleaned_multivariate.csv"
+PHASE3_UNIV = BASE_DIR / "phase3_output" / "phase3_cleaned_univ.csv"
+PHASE4_DIR = BASE_DIR / "phase4_output"
+
+SCRIPTS = [
+    (
+        "fine_tune_famd.py",
+        ["--input", PHASE3_MULTI, "--output", PHASE4_DIR / "fine_tune_famd"],
+    ),
+    (
+        "fine_tuning_mca.py",
+        [
+            "--phase1",
+            PHASE1_CSV,
+            "--phase2",
+            PHASE2_CSV,
+            "--phase3",
+            PHASE3_MULTI,
+            "--output",
+            PHASE4_DIR / "fine_tune_mca",
+        ],
+    ),
+    (
+        "fine_tune_mfa.py",
+        ["--input", PHASE3_MULTI, "--output", PHASE4_DIR / "fine_tune_mfa"],
+    ),
+    (
+        "pacmap_fine_tune.py",
+        ["--input", PHASE3_MULTI, "--output", PHASE4_DIR / "fine_tune_pacmap"],
+    ),
+    (
+        "fine_tune_pca.py",
+        ["--input", PHASE3_MULTI, "--output", PHASE4_DIR / "fine_tune_pca"],
+    ),
+    (
+        "fine_tune_pcamix.py",
+        ["--input", PHASE3_MULTI, "--output", PHASE4_DIR / "fine_tune_pcamix"],
+    ),
+    (
+        "phase4_fine_tune_phate.py",
+        [
+            "--multi",
+            PHASE3_MULTI,
+            "--univ",
+            PHASE3_UNIV,
+            "--output",
+            PHASE4_DIR / "fine_tune_phate",
+        ],
+    ),
+    (
+        "fine_tune_tsne.py",
+        ["--input", PHASE3_MULTI, "--output", PHASE4_DIR / "fine_tune_tsne"],
+    ),
+    (
+        "fine_tuning_umap.py",
+        ["--input", PHASE3_MULTI, "--output", PHASE4_DIR / "fine_tune_umap"],
+    ),
+]
+
+
+def _get_output_dir(args: list[Path | str]) -> Path | None:
+    """Return the path given to '--output' if present."""
+    for i, token in enumerate(args[:-1]):
+        if token == "--output":
+            return Path(args[i + 1])
+    return None
+
+
+def run_script(script: str, args: list[Path | str]) -> int:
+    """Run a fine‑tuning script and return its exit code."""
+    out_dir = _get_output_dir(args)
+    if out_dir and out_dir.exists() and any(out_dir.iterdir()):
+        print(f"Skipping {script}: output already exists")
+        return 0
+
+    cmd = [sys.executable, str(Path(__file__).parent / script)]
+    cmd += [str(a) for a in args]
+    env = os.environ.copy()
+    env.setdefault("OMP_NUM_THREADS", "1")
+    result = subprocess.run(cmd, env=env)
+    return result.returncode
+
+
+def main() -> None:
+    max_workers = min(len(SCRIPTS), os.cpu_count() or 1)
+    failed: list[str] = []
+    with ThreadPoolExecutor(max_workers=max_workers) as exe:
+        futures = {exe.submit(run_script, s, a): s for s, a in SCRIPTS}
+        for fut in as_completed(futures):
+            script = futures[fut]
+            try:
+                ret = fut.result()
+            except Exception:
+                ret = 1
+            if ret != 0:
+                failed.append(script)
+
+    if failed:
+        print("Some scripts failed:", ", ".join(failed))
+    else:
+        print("All fine-tuning scripts completed successfully")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- skip rerunning fine-tuning jobs when output already exists
- run jobs concurrently with thread pool and OMP threads limited
- fix t-SNE and PHATE preprocessing for boolean columns
- handle PaCMAP versions lacking `init`
- skip invalid PCA setups
- allow UMAP to use multiple cores

## Testing
- `python -m py_compile run_fine_tuning_parallel.py fine_tune_tsne.py phase4_fine_tune_phate.py pacmap_fine_tune.py fine_tune_pca.py fine_tuning_umap.py`