### PR TITLE
Improve parallel fine tuning launcher

### DIFF
--- a/fine_tune_pca.py
+++ b/fine_tune_pca.py
@@ -60,6 +60,8 @@ def run_pca_grid(X: np.ndarray, columns: list[str]):
     sil_rows = []
     config_id = 0
     for n_comp, solver, whiten in itertools.product(N_COMPONENTS, SVD_SOLVERS, WHITEN_OPTIONS):
+        if n_comp > X.shape[1]:
+            continue
         logging.info("PCA n_components=%d solver=%s whiten=%s", n_comp, solver, whiten)
         pca = PCA(n_components=n_comp, svd_solver=solver, whiten=whiten, random_state=0)
         X_pca = pca.fit_transform(X)

--- a/fine_tune_tsne.py
+++ b/fine_tune_tsne.py
@@ -39,14 +39,22 @@ def load_preprocess(csv_path: str) -> tuple[pd.DataFrame, np.ndarray]:
     cat_cols = df.select_dtypes(exclude="number").columns.tolist()
 
     # Imputation
-    df_num = df[num_cols].fillna(df[num_cols].mean())
-    df_cat = df[cat_cols].fillna("unknown")
+    df_num = df[num_cols].copy()
+    for c in num_cols:
+        if df_num[c].isna().all():
+            df_num[c] = 0
+        else:
+            df_num[c] = df_num[c].fillna(df_num[c].mean())
+    df_cat = df[cat_cols].apply(lambda s: s.astype(str)).fillna("unknown")
 
     # Encoding / scaling
     scaler = StandardScaler()
     X_num = scaler.fit_transform(df_num)
 
-    encoder = OneHotEncoder(handle_unknown="ignore", sparse=False)
+    try:
+        encoder = OneHotEncoder(handle_unknown="ignore", sparse_output=False)
+    except TypeError:  # older scikit-learn
+        encoder = OneHotEncoder(handle_unknown="ignore", sparse=False)
     X_cat = encoder.fit_transform(df_cat)
 
     X_all = np.hstack([X_num, X_cat])

--- a/phase4_fine_tune_phate.py
+++ b/phase4_fine_tune_phate.py
@@ -43,9 +43,13 @@ def preprocess(df: pd.DataFrame) -> tuple[pd.DataFrame, List[str], List[str], np
     cat_cols = [c for c in df.columns if c not in num_cols]
 
     if num_cols:
-        df[num_cols] = df[num_cols].fillna(df[num_cols].median())
+        for c in num_cols:
+            if df[c].isna().all():
+                df[c] = 0
+            else:
+                df[c] = df[c].fillna(df[c].median())
     for c in cat_cols:
-        df[c] = df[c].fillna("Non renseigné")
+        df[c] = df[c].astype(str).fillna("Non renseigné")
 
     scaler = StandardScaler()
     X_num = scaler.fit_transform(df[num_cols]) if num_cols else np.empty((len(df), 0))

--- a/run_fine_tuning_parallel.py
+++ b/run_fine_tuning_parallel.py
@@ -1,0 +1,109 @@
+import sys
+import os
+import subprocess
+from pathlib import Path
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+BASE_DIR = Path(r"D:\DATAPREDICT\DATAPREDICT 2024\Missions\Digora")
+PHASE1_CSV = BASE_DIR / "phase1_output" / "export_phase1_cleaned.csv"
+PHASE2_CSV = BASE_DIR / "phase2_output" / "phase2_business_variables.csv"
+PHASE3_MULTI = BASE_DIR / "phase3_output" / "phase3_cleaned_multivariate.csv"
+PHASE3_UNIV = BASE_DIR / "phase3_output" / "phase3_cleaned_univ.csv"
+PHASE4_DIR = BASE_DIR / "phase4_output"
+
+SCRIPTS = [
+    (
+        "fine_tune_famd.py",
+        ["--input", PHASE3_MULTI, "--output", PHASE4_DIR / "fine_tune_famd"],
+    ),
+    (
+        "fine_tuning_mca.py",
+        [
+            "--phase1",
+            PHASE1_CSV,
+            "--phase2",
+            PHASE2_CSV,
+            "--phase3",
+            PHASE3_MULTI,
+            "--output",
+            PHASE4_DIR / "fine_tune_mca",
+        ],
+    ),
+    (
+        "fine_tune_mfa.py",
+        ["--input", PHASE3_MULTI, "--output", PHASE4_DIR / "fine_tune_mfa"],
+    ),
+    (
+        "pacmap_fine_tune.py",
+        ["--input", PHASE3_MULTI, "--output", PHASE4_DIR / "fine_tune_pacmap"],
+    ),
+    (
+        "fine_tune_pca.py",
+        ["--input", PHASE3_MULTI, "--output", PHASE4_DIR / "fine_tune_pca"],
+    ),
+    (
+        "fine_tune_pcamix.py",
+        ["--input", PHASE3_MULTI, "--output", PHASE4_DIR / "fine_tune_pcamix"],
+    ),
+    (
+        "phase4_fine_tune_phate.py",
+        [
+            "--multi",
+            PHASE3_MULTI,
+            "--univ",
+            PHASE3_UNIV,
+            "--output",
+            PHASE4_DIR / "fine_tune_phate",
+        ],
+    ),
+    (
+        "fine_tune_tsne.py",
+        ["--input", PHASE3_MULTI, "--output", PHASE4_DIR / "fine_tune_tsne"],
+    ),
+    (
+        "fine_tuning_umap.py",
+        ["--input", PHASE3_MULTI, "--output", PHASE4_DIR / "fine_tune_umap"],
+    ),
+]
+
+
+def run_script(script: str, args: list[Path | str]) -> int:
+    """Run a fine-tuning script and return its exit code."""
+    cmd = [sys.executable, str(Path(__file__).parent / script)]
+    cmd += [str(a) for a in args]
+    env = os.environ.copy()
+    env.setdefault("OMP_NUM_THREADS", "1")
+    result = subprocess.run(cmd, env=env)
+    return result.returncode
+
+
+def main() -> None:
+    max_workers = min(len(SCRIPTS), os.cpu_count() or 1)
+    failed: list[str] = []
+    with ThreadPoolExecutor(max_workers=max_workers) as exe:
+        future_to_script = {}
+        for script, args in SCRIPTS:
+            out_arg = args[-1] if args else None
+            if isinstance(out_arg, Path) and out_arg.exists() and any(out_arg.iterdir()):
+                print(f"Skipping {script}: output already exists")
+                continue
+            future = exe.submit(run_script, script, args)
+            future_to_script[future] = script
+
+        for future in as_completed(future_to_script):
+            script = future_to_script[future]
+            try:
+                ret = future.result()
+            except Exception:
+                ret = 1
+            if ret != 0:
+                failed.append(script)
+
+    if failed:
+        print("Some scripts failed:", ", ".join(failed))
+    else:
+        print("All fine-tuning scripts completed successfully")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- skip completed fine tuning jobs and use a thread pool
- limit CPU usage for each job with `OMP_NUM_THREADS=1`
- robust preprocessing to avoid NaNs and boolean issues
- guard PCA runs with too many components

## Testing
- `python -m py_compile run_fine_tuning_parallel.py fine_tune_tsne.py phase4_fine_tune_phate.py pacmap_fine_tune.py fine_tuning_mca.py fine_tune_pca.py fine_tuning_umap.py`
