### PR TITLE
Add parallel runner with skipping and fix fine-tuning scripts

### DIFF
--- a/fine_tune_pca.py
+++ b/fine_tune_pca.py
@@ -59,10 +59,16 @@ def run_pca_grid(X: np.ndarray, columns: list[str]):
     contrib_rows = []
     sil_rows = []
     config_id = 0
+    max_valid = min(X.shape[0], X.shape[1])
     for n_comp, solver, whiten in itertools.product(N_COMPONENTS, SVD_SOLVERS, WHITEN_OPTIONS):
+        if n_comp > max_valid:
+            continue
         logging.info("PCA n_components=%d solver=%s whiten=%s", n_comp, solver, whiten)
-        pca = PCA(n_components=n_comp, svd_solver=solver, whiten=whiten, random_state=0)
-        X_pca = pca.fit_transform(X)
+        try:
+            pca = PCA(n_components=n_comp, svd_solver=solver, whiten=whiten, random_state=0)
+            X_pca = pca.fit_transform(X)
+        except ValueError:
+            continue
 
         cum_var = np.cumsum(pca.explained_variance_ratio_)
         for i, (var_ratio, sv) in enumerate(zip(pca.explained_variance_ratio_, pca.singular_values_), 1):

--- a/fine_tune_tsne.py
+++ b/fine_tune_tsne.py
@@ -37,6 +37,9 @@ def load_preprocess(csv_path: str) -> tuple[pd.DataFrame, np.ndarray]:
     df = pd.read_csv(csv_path)
     num_cols = df.select_dtypes(include="number").columns.tolist()
     cat_cols = df.select_dtypes(exclude="number").columns.tolist()
+    # ensure booleans are strings for OneHotEncoder
+    for col in df.select_dtypes(include="bool").columns:
+        df[col] = df[col].astype(str)
 
     # Imputation
     df_num = df[num_cols].fillna(df[num_cols].mean())
@@ -46,7 +49,10 @@ def load_preprocess(csv_path: str) -> tuple[pd.DataFrame, np.ndarray]:
     scaler = StandardScaler()
     X_num = scaler.fit_transform(df_num)
 
-    encoder = OneHotEncoder(handle_unknown="ignore", sparse=False)
+    try:
+        encoder = OneHotEncoder(handle_unknown="ignore", sparse_output=False)
+    except TypeError:  # older scikit-learn
+        encoder = OneHotEncoder(handle_unknown="ignore", sparse=False)
     X_cat = encoder.fit_transform(df_cat)
 
     X_all = np.hstack([X_num, X_cat])

--- a/fine_tuning_mca.py
+++ b/fine_tuning_mca.py
@@ -98,12 +98,18 @@ def plot_scree(inertia: np.ndarray, base: str) -> Path:
 
 
 # ----------------------------------------------------------------------
-def plot_correlation(coords: pd.DataFrame, base: str, axes_pair: tuple[str, str]) -> Path:
+def plot_correlation(coords: pd.DataFrame, base: str, axes_pair: tuple[str, str]) -> Path | None:
+    if not set(axes_pair).issubset(coords.columns):
+        return None
     fig = plt.figure(figsize=(12, 6), dpi=200)
     ax = plt.gca()
-    subset = coords[[axes_pair[0], axes_pair[1]]].copy()
+    subset = coords[list(axes_pair)].copy()
     subset.columns = ["F1", "F2"]
-    plot_correlation_circle(ax, subset, f"Cercle des corrélations ({axes_pair[0]}–{axes_pair[1]})")
+    plot_correlation_circle(
+        ax,
+        subset,
+        f"Cercle des corrélations ({axes_pair[0]}–{axes_pair[1]})",
+    )
     plt.tight_layout()
     path = FIG_DIR / f"circle_{axes_pair[0].lower()}_{axes_pair[1].lower()}_{base}.png"
     plt.savefig(path)
@@ -258,9 +264,13 @@ def main() -> None:
                 # Figures
                 fig_paths = []
                 fig_paths.append(plot_scree(inertia, base))
-                fig_paths.append(plot_correlation(cols, base, ("F1", "F2")))
+                fig_path = plot_correlation(cols, base, ("F1", "F2"))
+                if fig_path:
+                    fig_paths.append(fig_path)
                 if "F3" in cols.columns:
-                    fig_paths.append(plot_correlation(cols.rename(columns={"F3": "F2"}), base, ("F1", "F3")))
+                    fig_path = plot_correlation(cols, base, ("F1", "F3"))
+                    if fig_path:
+                        fig_paths.append(fig_path)
                 indiv2d, indiv3d = plot_individuals(rows, df, base)
                 mod, mod_zoom = plot_modalities(cols, base)
                 fig_paths.extend([indiv2d, indiv3d, mod, mod_zoom])

--- a/fine_tuning_umap.py
+++ b/fine_tuning_umap.py
@@ -27,7 +27,7 @@ def parse_args() -> argparse.Namespace:
 
 DATA_PATH = Path()
 OUTPUT_DIR = Path()
-RANDOM_STATE = 42
+RANDOM_STATE = None
 
 
 def setup_logger() -> logging.Logger:
@@ -83,14 +83,13 @@ def grid_search_umap(X: np.ndarray, logger: logging.Logger):
                     md,
                     metric,
                 )
-                reducer = umap.UMAP(
-                    n_neighbors=nn,
-                    min_dist=md,
-                    metric=metric,
-                    random_state=RANDOM_STATE,
-                )
+                kwargs = dict(n_neighbors=nn, min_dist=md, metric=metric)
+                if RANDOM_STATE is not None:
+                    kwargs["random_state"] = RANDOM_STATE
+                reducer = umap.UMAP(**kwargs)
                 emb = reducer.fit_transform(X)
-                labels = KMeans(n_clusters=5, random_state=RANDOM_STATE).fit_predict(emb)
+                km_rs = RANDOM_STATE if RANDOM_STATE is not None else 0
+                labels = KMeans(n_clusters=5, random_state=km_rs).fit_predict(emb)
                 score = silhouette_score(emb, labels)
                 logger.info("Silhouette: %.3f", score)
                 results.append({
@@ -158,12 +157,10 @@ def main() -> None:
         metric,
         score,
     )
-    final_model = umap.UMAP(
-        n_neighbors=nn,
-        min_dist=md,
-        metric=metric,
-        random_state=RANDOM_STATE,
-    )
+    kwargs = dict(n_neighbors=nn, min_dist=md, metric=metric)
+    if RANDOM_STATE is not None:
+        kwargs["random_state"] = RANDOM_STATE
+    final_model = umap.UMAP(**kwargs)
     embedding = final_model.fit_transform(X)
     pd.DataFrame(embedding, columns=["UMAP1", "UMAP2"]).to_csv(
         OUTPUT_DIR / "umap_embeddings.csv", index=False

--- a/phase4_fine_tune_phate.py
+++ b/phase4_fine_tune_phate.py
@@ -46,6 +46,8 @@ def preprocess(df: pd.DataFrame) -> tuple[pd.DataFrame, List[str], List[str], np
         df[num_cols] = df[num_cols].fillna(df[num_cols].median())
     for c in cat_cols:
         df[c] = df[c].fillna("Non renseigné")
+        if df[c].dtype == bool:
+            df[c] = df[c].astype(str)
 
     scaler = StandardScaler()
     X_num = scaler.fit_transform(df[num_cols]) if num_cols else np.empty((len(df), 0))

--- a/run_fine_tuning_parallel.py
+++ b/run_fine_tuning_parallel.py
@@ -1,0 +1,117 @@
+import sys
+import os
+import sys
+import subprocess
+from pathlib import Path
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+BASE_DIR = Path(r"D:\DATAPREDICT\DATAPREDICT 2024\Missions\Digora")
+PHASE1_CSV = BASE_DIR / "phase1_output" / "export_phase1_cleaned.csv"
+PHASE2_CSV = BASE_DIR / "phase2_output" / "phase2_business_variables.csv"
+PHASE3_MULTI = BASE_DIR / "phase3_output" / "phase3_cleaned_multivariate.csv"
+PHASE3_UNIV = BASE_DIR / "phase3_output" / "phase3_cleaned_univ.csv"
+PHASE4_DIR = BASE_DIR / "phase4_output"
+
+SCRIPTS = [
+    (
+        "fine_tune_famd.py",
+        ["--input", PHASE3_MULTI, "--output", PHASE4_DIR / "fine_tune_famd"],
+    ),
+    (
+        "fine_tuning_mca.py",
+        [
+            "--phase1",
+            PHASE1_CSV,
+            "--phase2",
+            PHASE2_CSV,
+            "--phase3",
+            PHASE3_MULTI,
+            "--output",
+            PHASE4_DIR / "fine_tune_mca",
+        ],
+    ),
+    (
+        "fine_tune_mfa.py",
+        ["--input", PHASE3_MULTI, "--output", PHASE4_DIR / "fine_tune_mfa"],
+    ),
+    (
+        "pacmap_fine_tune.py",
+        ["--input", PHASE3_MULTI, "--output", PHASE4_DIR / "fine_tune_pacmap"],
+    ),
+    (
+        "fine_tune_pca.py",
+        ["--input", PHASE3_MULTI, "--output", PHASE4_DIR / "fine_tune_pca"],
+    ),
+    (
+        "fine_tune_pcamix.py",
+        ["--input", PHASE3_MULTI, "--output", PHASE4_DIR / "fine_tune_pcamix"],
+    ),
+    (
+        "phase4_fine_tune_phate.py",
+        [
+            "--multi",
+            PHASE3_MULTI,
+            "--univ",
+            PHASE3_UNIV,
+            "--output",
+            PHASE4_DIR / "fine_tune_phate",
+        ],
+    ),
+    (
+        "fine_tune_tsne.py",
+        ["--input", PHASE3_MULTI, "--output", PHASE4_DIR / "fine_tune_tsne"],
+    ),
+    (
+        "fine_tuning_umap.py",
+        ["--input", PHASE3_MULTI, "--output", PHASE4_DIR / "fine_tune_umap"],
+    ),
+]
+
+
+def _has_results(out_dir: Path) -> bool:
+    """Return True if the given directory exists and contains any file."""
+    return out_dir.exists() and any(out_dir.iterdir())
+
+
+def run_script(script: str, args: list[Path | str]) -> int:
+    """Run a fine‑tuning script and return its exit code."""
+    cmd = [sys.executable, str(Path(__file__).parent / script)]
+    cmd += [str(a) for a in args]
+    env = os.environ.copy()
+    env.setdefault("OMP_NUM_THREADS", "1")
+    result = subprocess.run(cmd, env=env)
+    return result.returncode
+
+
+def main() -> None:
+    to_run: list[tuple[str, list[Path | str]]] = []
+    for script, args in SCRIPTS:
+        if "--output" in args:
+            out_idx = args.index("--output") + 1
+            out = Path(args[out_idx])
+            if _has_results(out):
+                print(f"Skipping {script}: output already exists")
+                continue
+        to_run.append((script, args))
+
+    max_workers = min(len(to_run), os.cpu_count() or 1)
+    failed: list[str] = []
+    with ThreadPoolExecutor(max_workers=max_workers) as exe:
+        futures = {exe.submit(run_script, s, a): s for s, a in to_run}
+        for fut in as_completed(futures):
+            script = futures[fut]
+            try:
+                ret = fut.result()
+            except Exception:
+                ret = 1
+            if ret != 0:
+                failed.append(script)
+
+    if failed:
+        print("Some scripts failed:", ", ".join(failed))
+    else:
+        print("All fine-tuning scripts completed successfully")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- create thread-based launcher that skips finished outputs
- make t-SNE preprocessing robust to sklearn changes
- handle boolean columns in PHATE preprocessing
- support PaCMAP versions without `init` argument
- guard MCA plotting when axes are missing
- skip invalid PCA component settings
- allow UMAP multi-threading and new encoder

## Testing
- `python -m py_compile run_fine_tuning_parallel.py fine_tune_tsne.py phase4_fine_tune_phate.py pacmap_fine_tune.py fine_tuning_mca.py fine_tune_pca.py fine_tuning_umap.py fine_tune_famd.py fine_tune_pcamix.py fine_tune_mfa.py`