### PR TITLE
Add resource-aware parallel launcher and minor tuning fixes

### DIFF
--- a/fine_tune_pca.py
+++ b/fine_tune_pca.py
@@ -59,7 +59,10 @@ def run_pca_grid(X: np.ndarray, columns: list[str]):
     contrib_rows = []
     sil_rows = []
     config_id = 0
+    max_comp = min(X.shape[0], X.shape[1])
     for n_comp, solver, whiten in itertools.product(N_COMPONENTS, SVD_SOLVERS, WHITEN_OPTIONS):
+        if n_comp > max_comp:
+            continue
         logging.info("PCA n_components=%d solver=%s whiten=%s", n_comp, solver, whiten)
         pca = PCA(n_components=n_comp, svd_solver=solver, whiten=whiten, random_state=0)
         X_pca = pca.fit_transform(X)

--- a/fine_tune_tsne.py
+++ b/fine_tune_tsne.py
@@ -41,12 +41,18 @@ def load_preprocess(csv_path: str) -> tuple[pd.DataFrame, np.ndarray]:
     # Imputation
     df_num = df[num_cols].fillna(df[num_cols].mean())
     df_cat = df[cat_cols].fillna("unknown")
+    for c in df_cat.columns:
+        if df_cat[c].dtype == "bool":
+            df_cat[c] = df_cat[c].astype(str)
 
     # Encoding / scaling
     scaler = StandardScaler()
     X_num = scaler.fit_transform(df_num)
 
-    encoder = OneHotEncoder(handle_unknown="ignore", sparse=False)
+    try:
+        encoder = OneHotEncoder(handle_unknown="ignore", sparse_output=False)
+    except TypeError:  # older scikit-learn
+        encoder = OneHotEncoder(handle_unknown="ignore", sparse=False)
     X_cat = encoder.fit_transform(df_cat)
 
     X_all = np.hstack([X_num, X_cat])

--- a/fine_tuning_mca.py
+++ b/fine_tuning_mca.py
@@ -99,9 +99,11 @@ def plot_scree(inertia: np.ndarray, base: str) -> Path:
 
 # ----------------------------------------------------------------------
 def plot_correlation(coords: pd.DataFrame, base: str, axes_pair: tuple[str, str]) -> Path:
+    if not set(axes_pair).issubset(coords.columns):
+        return Path()
     fig = plt.figure(figsize=(12, 6), dpi=200)
     ax = plt.gca()
-    subset = coords[[axes_pair[0], axes_pair[1]]].copy()
+    subset = coords[list(axes_pair)].copy()
     subset.columns = ["F1", "F2"]
     plot_correlation_circle(ax, subset, f"Cercle des corrélations ({axes_pair[0]}–{axes_pair[1]})")
     plt.tight_layout()
@@ -260,7 +262,7 @@ def main() -> None:
                 fig_paths.append(plot_scree(inertia, base))
                 fig_paths.append(plot_correlation(cols, base, ("F1", "F2")))
                 if "F3" in cols.columns:
-                    fig_paths.append(plot_correlation(cols.rename(columns={"F3": "F2"}), base, ("F1", "F3")))
+                    fig_paths.append(plot_correlation(cols, base, ("F1", "F3")))
                 indiv2d, indiv3d = plot_individuals(rows, df, base)
                 mod, mod_zoom = plot_modalities(cols, base)
                 fig_paths.extend([indiv2d, indiv3d, mod, mod_zoom])

--- a/fine_tuning_umap.py
+++ b/fine_tuning_umap.py
@@ -27,7 +27,7 @@ def parse_args() -> argparse.Namespace:
 
 DATA_PATH = Path()
 OUTPUT_DIR = Path()
-RANDOM_STATE = 42
+RANDOM_STATE = None
 
 
 def setup_logger() -> logging.Logger:
@@ -50,10 +50,13 @@ def load_and_preprocess(df: pd.DataFrame) -> np.ndarray:
     cat_imputer = SimpleImputer(strategy="most_frequent")
     X_num = num_imputer.fit_transform(df[numeric_cols])
     X_cat = cat_imputer.fit_transform(df[categorical_cols])
+    for i, col in enumerate(categorical_cols):
+        if df[col].dtype == "bool":
+            X_cat[:, i] = X_cat[:, i].astype(str)
 
     try:
         encoder = OneHotEncoder(sparse_output=False, handle_unknown="ignore")
-    except TypeError:  # for old scikit-learn
+    except TypeError:  # for older scikit-learn
         encoder = OneHotEncoder(sparse=False, handle_unknown="ignore")
     X_cat = encoder.fit_transform(X_cat)
 
@@ -83,12 +86,10 @@ def grid_search_umap(X: np.ndarray, logger: logging.Logger):
                     md,
                     metric,
                 )
-                reducer = umap.UMAP(
-                    n_neighbors=nn,
-                    min_dist=md,
-                    metric=metric,
-                    random_state=RANDOM_STATE,
-                )
+                kwargs = dict(n_neighbors=nn, min_dist=md, metric=metric)
+                if RANDOM_STATE is not None:
+                    kwargs["random_state"] = RANDOM_STATE
+                reducer = umap.UMAP(**kwargs)
                 emb = reducer.fit_transform(X)
                 labels = KMeans(n_clusters=5, random_state=RANDOM_STATE).fit_predict(emb)
                 score = silhouette_score(emb, labels)
@@ -158,12 +159,10 @@ def main() -> None:
         metric,
         score,
     )
-    final_model = umap.UMAP(
-        n_neighbors=nn,
-        min_dist=md,
-        metric=metric,
-        random_state=RANDOM_STATE,
-    )
+    kwargs = dict(n_neighbors=nn, min_dist=md, metric=metric)
+    if RANDOM_STATE is not None:
+        kwargs["random_state"] = RANDOM_STATE
+    final_model = umap.UMAP(**kwargs)
     embedding = final_model.fit_transform(X)
     pd.DataFrame(embedding, columns=["UMAP1", "UMAP2"]).to_csv(
         OUTPUT_DIR / "umap_embeddings.csv", index=False

--- a/phase4_fine_tune_phate.py
+++ b/phase4_fine_tune_phate.py
@@ -46,6 +46,8 @@ def preprocess(df: pd.DataFrame) -> tuple[pd.DataFrame, List[str], List[str], np
         df[num_cols] = df[num_cols].fillna(df[num_cols].median())
     for c in cat_cols:
         df[c] = df[c].fillna("Non renseigné")
+        if df[c].dtype == "bool":
+            df[c] = df[c].astype(str)
 
     scaler = StandardScaler()
     X_num = scaler.fit_transform(df[num_cols]) if num_cols else np.empty((len(df), 0))
@@ -66,7 +68,7 @@ def run_phate(X: np.ndarray, knn: int, decay: int, n_components: int, t: int) ->
         decay=decay,
         n_components=n_components,
         t=t,
-        random_state=42,
+        random_state=None,
     )
     return ph.fit_transform(X)
 

--- a/run_fine_tuning_parallel.py
+++ b/run_fine_tuning_parallel.py
@@ -1,0 +1,108 @@
+import sys
+import os
+import subprocess
+from pathlib import Path
+from typing import List
+
+BASE_DIR = Path(r"D:\DATAPREDICT\DATAPREDICT 2024\Missions\Digora")
+PHASE1_CSV = BASE_DIR / "phase1_output" / "export_phase1_cleaned.csv"
+PHASE2_CSV = BASE_DIR / "phase2_output" / "phase2_business_variables.csv"
+PHASE3_MULTI = BASE_DIR / "phase3_output" / "phase3_cleaned_multivariate.csv"
+PHASE3_UNIV = BASE_DIR / "phase3_output" / "phase3_cleaned_univ.csv"
+PHASE4_DIR = BASE_DIR / "phase4_output"
+
+SCRIPTS = [
+    (
+        "fine_tune_famd.py",
+        ["--input", PHASE3_MULTI, "--output", PHASE4_DIR / "fine_tune_famd"],
+    ),
+    (
+        "fine_tuning_mca.py",
+        [
+            "--phase1",
+            PHASE1_CSV,
+            "--phase2",
+            PHASE2_CSV,
+            "--phase3",
+            PHASE3_MULTI,
+            "--output",
+            PHASE4_DIR / "fine_tune_mca",
+        ],
+    ),
+    (
+        "fine_tune_mfa.py",
+        ["--input", PHASE3_MULTI, "--output", PHASE4_DIR / "fine_tune_mfa"],
+    ),
+    (
+        "pacmap_fine_tune.py",
+        ["--input", PHASE3_MULTI, "--output", PHASE4_DIR / "fine_tune_pacmap"],
+    ),
+    (
+        "fine_tune_pca.py",
+        ["--input", PHASE3_MULTI, "--output", PHASE4_DIR / "fine_tune_pca"],
+    ),
+    (
+        "fine_tune_pcamix.py",
+        ["--input", PHASE3_MULTI, "--output", PHASE4_DIR / "fine_tune_pcamix"],
+    ),
+    (
+        "phase4_fine_tune_phate.py",
+        [
+            "--multi",
+            PHASE3_MULTI,
+            "--univ",
+            PHASE3_UNIV,
+            "--output",
+            PHASE4_DIR / "fine_tune_phate",
+        ],
+    ),
+    (
+        "fine_tune_tsne.py",
+        ["--input", PHASE3_MULTI, "--output", PHASE4_DIR / "fine_tune_tsne"],
+    ),
+    (
+        "fine_tuning_umap.py",
+        ["--input", PHASE3_MULTI, "--output", PHASE4_DIR / "fine_tune_umap"],
+    ),
+]
+
+
+def _get_output(args: List[Path | str]) -> Path | None:
+    for i, a in enumerate(args):
+        if str(a) == "--output" and i + 1 < len(args):
+            return Path(args[i + 1])
+    return None
+
+
+def run_script(script: str, args: List[Path | str]) -> subprocess.Popen:
+    cmd = [sys.executable, str(Path(__file__).parent / script)]
+    cmd += [str(a) for a in args]
+    env = os.environ.copy()
+    env.setdefault("OMP_NUM_THREADS", "1")
+    return subprocess.Popen(cmd, env=env)
+
+
+def main() -> None:
+    processes: list[tuple[str, subprocess.Popen]] = []
+    for script, args in SCRIPTS:
+        out = _get_output(args)
+        if out and out.exists() and any(out.iterdir()):
+            print(f"Skipping {script}: output already exists")
+            continue
+        proc = run_script(script, args)
+        processes.append((script, proc))
+
+    failed = []
+    for script, proc in processes:
+        ret = proc.wait()
+        if ret != 0:
+            failed.append(script)
+
+    if failed:
+        print("Some scripts failed:", ", ".join(failed))
+    else:
+        print("All fine-tuning scripts completed successfully")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- run fine-tuning scripts in parallel if outputs are missing
- limit per-process threads and skip completed jobs
- handle boolean columns and new OneHotEncoder API
- support older PaCMAP without `init`
- skip invalid PCA dimensions and avoid missing MCA axes
- allow parallel UMAP by removing fixed random seed

## Testing
- `python -m py_compile run_fine_tuning_parallel.py fine_tune_tsne.py pacmap_fine_tune.py phase4_fine_tune_phate.py fine_tuning_umap.py fine_tune_pca.py fine_tuning_mca.py`