### PR TITLE
Fix omission of 'Catégorie' segment in Phase 4

### DIFF
--- a/fine_tune_tsne.py
+++ b/fine_tune_tsne.py
@@ -137,7 +137,7 @@ def export_results(
 
     # Save embeddings with labels
     label_cols_all = [
-        "Catégories",
+        "Catégorie",
         "Entité opérationnelle",
         "Pilier",
         "Sous-catégorie",

--- a/phase4v2.py
+++ b/phase4v2.py
@@ -49,7 +49,7 @@ CONFIG = {
 
 # Principal CRM segmentation columns used to generate variant scatters
 SEGMENT_COLUMNS = [
-    "Catégories",
+    "Catégorie",
     "Entité opérationnelle",
     "Pilier",
     "Sous-catégorie",


### PR DESCRIPTION
## Summary
- ensure the `Catégorie` column is included in all segmentation plots
- update t-SNE utility to export embeddings labelled with `Catégorie`

## Testing
- `python test_run_famd.py`
- `python test_run_pacmap.py`
- `python test_run_pcamix.py`
- `python test_run_phate.py`
