### PR TITLE
Fix omission of 'Catégorie' segment in Phase 4

### DIFF
--- a/fine_tune_tsne.py
+++ b/fine_tune_tsne.py
@@ -137,7 +137,7 @@ def export_results(
 
     # Save embeddings with labels
     label_cols_all = [
-        "Catégories",
+        "Catégorie",
         "Entité opérationnelle",
         "Pilier",
         "Sous-catégorie",

--- a/fine_tuning_mca.py
+++ b/fine_tuning_mca.py
@@ -10,7 +10,7 @@ import matplotlib.pyplot as plt
 from matplotlib.backends.backend_pdf import PdfPages
 import prince
 
-from phase4v2 import plot_correlation_circle
+from phase4v2 import plot_correlation_circle, scatter_all_segments
 
 import warnings
 warnings.filterwarnings("ignore", category=RuntimeWarning)
@@ -139,6 +139,12 @@ def plot_individuals(df_coords: pd.DataFrame, df_source: pd.DataFrame, base: str
         p2 = FIG_DIR / f"indiv_2d_{base}.png"
         plt.savefig(p2)
         plt.close()
+        scatter_all_segments(
+            df_coords[["F1", "F2"]],
+            df_source,
+            FIG_DIR,
+            f"indiv_{base}",
+        )
     if {"F1", "F2", "F3"}.issubset(df_coords.columns):
         from mpl_toolkits.mplot3d import Axes3D  # noqa: F401
         fig = plt.figure(figsize=(12, 6), dpi=200)

--- a/fine_tuning_umap.py
+++ b/fine_tuning_umap.py
@@ -175,7 +175,7 @@ def main() -> None:
     with open(OUTPUT_DIR / "umap_model.pkl", "wb") as f:
         pickle.dump(final_model, f)
 
-    for col in ["Pilier", "Sous-catégorie", "Statut commercial"]:
+    for col in ["Pilier", "Sous-catégorie", "Catégorie", "Statut commercial"]:
         export_scatter(embedding, df, col)
 
     logger.info("UMAP fine-tuning complete")

--- a/pacmap_fine_tune.py
+++ b/pacmap_fine_tune.py
@@ -30,7 +30,7 @@ except TypeError:  # pragma: no cover - older pacmap
     _PACMAP_HAS_INIT = False
 
 # Import helper functions for variable selection and missing value handling
-from phase4v2 import select_variables, handle_missing_values
+from phase4v2 import select_variables, handle_missing_values, scatter_all_segments
 
 
 
@@ -206,6 +206,13 @@ def main() -> None:
             plt.savefig(fig_path)
             plt.close()
             generated_files.append(fig_path)
+
+            scatter_all_segments(
+                coord_df[["PACMAP1", "PACMAP2"]],
+                df_active,
+                fig_dir,
+                f"pacmap_{nn}_{mn}",
+            )
 
         if nc >= 3:
             from mpl_toolkits.mplot3d import Axes3D  # noqa: F401

--- a/phase4_fine_tune_phate.py
+++ b/phase4_fine_tune_phate.py
@@ -20,7 +20,7 @@ from sklearn.preprocessing import StandardScaler, OneHotEncoder
 
 import phate
 
-from phase4v2 import select_variables, handle_missing_values
+from phase4v2 import select_variables, handle_missing_values, scatter_all_segments
 
 import warnings
 warnings.filterwarnings("ignore", category=RuntimeWarning)
@@ -206,6 +206,13 @@ def main() -> None:
             plt.savefig(fig_path)
             plt.close()
             generated_files.append(fig_path)
+
+            scatter_all_segments(
+                coord_df[["PHATE1", "PHATE2"]],
+                df_active,
+                fig_dir,
+                f"phate_{nc}D_knn{nn}_t{tt}",
+            )
 
     index_path = out_dir / "index_phate.txt"
     with open(index_path, "w", encoding="utf-8") as f:

--- a/phase4v2.py
+++ b/phase4v2.py
@@ -49,7 +49,7 @@ CONFIG = {
 
 # Principal CRM segmentation columns used to generate variant scatters
 SEGMENT_COLUMNS = [
-    "Catégories",
+    "Catégorie",
     "Entité opérationnelle",
     "Pilier",
     "Sous-catégorie",


### PR DESCRIPTION
## Summary
- ensure the `Catégorie` column is included in all segmentation plots
- update tuning scripts (MCA, PaCMAP, PHATE, UMAP) to generate segment-specific scatters

## Testing
- `python test_run_famd.py`
- `python test_run_pacmap.py` *(fails: library missing warning is expected)*
- `python test_run_pcamix.py`
- `python test_run_phate.py`
