### PR TITLE
Fix omission of 'Catégorie' in PCA scatter plots

### DIFF
--- a/fine_tune_pca.py
+++ b/fine_tune_pca.py
@@ -15,7 +15,8 @@ from sklearn.preprocessing import StandardScaler
 from sklearn.cluster import KMeans
 from sklearn.metrics import silhouette_score
 
-from phase4v2 import plot_correlation_circle
+from phase4v2 import plot_correlation_circle, scatter_all_segments
+from standalone_utils import prepare_active_dataset
 
 import warnings
 warnings.filterwarnings("ignore", category=RuntimeWarning)
@@ -252,11 +253,11 @@ def main() -> None:
     logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
     out_dir.mkdir(parents=True, exist_ok=True)
 
-    df_quant, quant_cols = load_quantitative_data(data_path)
+    df_active, quant_cols, _ = prepare_active_dataset(data_path, out_dir)
     logging.info("Variables quantitatives utilisées : %s", quant_cols)
 
     scaler = StandardScaler()
-    X = scaler.fit_transform(df_quant)
+    X = scaler.fit_transform(df_active[quant_cols])
 
     results, exp_df, load_df, contrib_df, sil_df = run_pca_grid(X, quant_cols)
 
@@ -278,6 +279,9 @@ def main() -> None:
     plot_correlation_and_contrib(out_dir, best_var_res["loadings"], quant_cols, "best_variance")
     plot_correlation_and_contrib(out_dir, best_sil_res["loadings"], quant_cols, "best_silhouette")
     plot_best_clusters(out_dir, best_sil_res["scores"], int(best_k))
+
+    scores_df = pd.DataFrame(best_sil_res["scores"][:, :2], index=df_active.index, columns=["F1", "F2"])
+    scatter_all_segments(scores_df, df_active, out_dir, "pca_best")
 
     write_index(out_dir)
 

--- a/fine_tune_tsne.py
+++ b/fine_tune_tsne.py
@@ -137,7 +137,7 @@ def export_results(
 
     # Save embeddings with labels
     label_cols_all = [
-        "Catégories",
+        "Catégorie",
         "Entité opérationnelle",
         "Pilier",
         "Sous-catégorie",

--- a/phase4v2.py
+++ b/phase4v2.py
@@ -49,7 +49,7 @@ CONFIG = {
 
 # Principal CRM segmentation columns used to generate variant scatters
 SEGMENT_COLUMNS = [
-    "Catégories",
+    "Catégorie",
     "Entité opérationnelle",
     "Pilier",
     "Sous-catégorie",
@@ -2696,6 +2696,13 @@ def export_pca_results(
         plt.tight_layout()
         plt.savefig(output_dir / "pca_indiv_plot.png")
         plt.close()
+
+        scatter_all_segments(
+            row_coords[["F1", "F2"]],
+            df_active,
+            output_dir,
+            "pca_indiv",
+        )
 
     # Individuals 3D
     if {"F1", "F2", "F3"}.issubset(row_coords.columns):


### PR DESCRIPTION
## Summary
- generate segmentation plots for PCA results
- expose these segmentation scatters via `export_pca_results`
- load full dataset in the PCA tuner and export segment-coloured scatters

## Testing
- `python test_run_famd.py`
- `python test_run_pacmap.py` *(library missing warning is expected)*
- `python test_run_pcamix.py`
- `python test_run_phate.py`
