### PR TITLE
Fix segmentation data in fine-tuning scripts

### DIFF
--- a/fine_tune_famd.py
+++ b/fine_tune_famd.py
@@ -7,7 +7,12 @@ import argparse
 import logging
 from pathlib import Path
 
-from phase4v2 import run_famd, export_famd_results
+from phase4v2 import (
+    run_famd,
+    export_famd_results,
+    load_data,
+    prepare_data,
+)
 from standalone_utils import prepare_active_dataset
 
 import warnings
@@ -37,6 +42,10 @@ def main() -> None:
 
     df_active, quant_vars, qual_vars = prepare_active_dataset(str(data_path), out_dir)
 
+    # Load the full cleaned dataset to keep segmentation columns for plots
+    df_full = prepare_data(load_data(str(data_path)))
+    df_full = df_full.loc[df_active.index]
+
     famd, inertia, rows, cols, contrib = run_famd(
         df_active,
         quant_vars,
@@ -53,7 +62,7 @@ def main() -> None:
         quant_vars,
         qual_vars,
         out_dir,
-        df_active=df_active,
+        df_active=df_full,
     )
     logging.info("FAMD fine-tuning complete")
 

--- a/fine_tune_mfa.py
+++ b/fine_tune_mfa.py
@@ -10,7 +10,12 @@ from sklearn.cluster import KMeans
 from sklearn.metrics import silhouette_score, calinski_harabasz_score
 
 from standalone_utils import prepare_active_dataset
-from phase4v2 import run_mfa, export_mfa_results
+from phase4v2 import (
+    run_mfa,
+    export_mfa_results,
+    load_data,
+    prepare_data,
+)
 
 import warnings
 warnings.filterwarnings("ignore", category=RuntimeWarning)
@@ -67,6 +72,10 @@ def main() -> None:
 
     df_active, quant_vars, qual_vars = prepare_active_dataset(input_file, out_dir)
 
+    # Keep segmentation columns by loading the full cleaned dataset
+    df_full = prepare_data(load_data(input_file))
+    df_full = df_full.loc[df_active.index]
+
     results = []
     best = None
     best_metrics = (-1.0, -1.0)
@@ -105,7 +114,14 @@ def main() -> None:
     else:
         model, rows, n_comp, weights = best
 
-    export_mfa_results(model, rows, out_dir / "best", quant_vars, qual_vars, df_active=df_active)
+    export_mfa_results(
+        model,
+        rows,
+        out_dir / "best",
+        quant_vars,
+        qual_vars,
+        df_active=df_full,
+    )
     logging.info("Best MFA with %d components", n_comp)
 
 

--- a/fine_tune_pcamix.py
+++ b/fine_tune_pcamix.py
@@ -7,7 +7,12 @@ import argparse
 import logging
 from pathlib import Path
 
-from phase4v2 import run_pcamix, export_pcamix_results
+from phase4v2 import (
+    run_pcamix,
+    export_pcamix_results,
+    load_data,
+    prepare_data,
+)
 from standalone_utils import prepare_active_dataset
 
 import warnings
@@ -37,6 +42,10 @@ def main() -> None:
 
     df_active, quant_vars, qual_vars = prepare_active_dataset(str(data_path), out_dir)
 
+    # Load cleaned dataset for segmentation scatters
+    df_full = prepare_data(load_data(str(data_path)))
+    df_full = df_full.loc[df_active.index]
+
     model, inertia, rows, cols = run_pcamix(
         df_active,
         quant_vars,
@@ -53,7 +62,7 @@ def main() -> None:
         out_dir,
         quant_vars,
         qual_vars,
-        df_active=df_active,
+        df_active=df_full,
     )
     logging.info("PCAmix fine-tuning complete")
 

--- a/phase4v2.py
+++ b/phase4v2.py
@@ -49,7 +49,7 @@ CONFIG = {
 
 # Principal CRM segmentation columns used to generate variant scatters
 SEGMENT_COLUMNS = [
-    "Catégories",
+    "Catégorie",
     "Entité opérationnelle",
     "Pilier",
     "Sous-catégorie",


### PR DESCRIPTION
## Summary
- keep the full cleaned dataset for segmentation plots in FAMD, MFA and PCAmix fine-tune scripts
- revert t‑SNE script to previous state

## Testing
- `python test_run_famd.py`
- `python test_run_pacmap.py` *(library missing warning is expected)*
- `python test_run_pcamix.py`
- `python test_run_phate.py`
