### PR TITLE
Fix segmentation dataset for all phase4 standalone scripts

### DIFF
--- a/fine_tune_tsne.py
+++ b/fine_tune_tsne.py
@@ -137,7 +137,7 @@ def export_results(
 
     # Save embeddings with labels
     label_cols_all = [
-        "Catégories",
+        "Catégorie",
         "Entité opérationnelle",
         "Pilier",
         "Sous-catégorie",

--- a/phase4_famd_simple.py
+++ b/phase4_famd_simple.py
@@ -11,8 +11,16 @@ import argparse
 import logging
 from pathlib import Path
 
-from phase4v2 import run_famd, export_famd_results
-from standalone_utils import prepare_active_dataset
+from phase4v2 import (
+    load_data,
+    prepare_data,
+    select_variables,
+    sanity_check,
+    handle_missing_values,
+    segment_data,
+    run_famd,
+    export_famd_results,
+)
 
 
 def main() -> None:
@@ -34,7 +42,14 @@ def main() -> None:
     logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
     out_dir = Path(args.output) / "FAMD"
 
-    df_active, quant_vars, qual_vars = prepare_active_dataset(args.input, out_dir)
+    df_raw = load_data(args.input)
+    df_clean = prepare_data(df_raw)
+    df_active_tmp, quant_vars, qual_vars = select_variables(df_clean)
+    quant_vars, qual_vars = sanity_check(df_active_tmp, quant_vars, qual_vars)
+    df_active = df_active_tmp[quant_vars + qual_vars]
+    df_active = handle_missing_values(df_active, quant_vars, qual_vars)
+    segment_data(df_active, qual_vars, out_dir)
+    df_full = df_clean.loc[df_active.index]
 
     famd_cfg = {
         "weighting": args.weighting,
@@ -60,7 +75,7 @@ def main() -> None:
         quant_vars,
         qual_vars,
         out_dir,
-        df_active=df_active,
+        df_active=df_full,
     )
     logging.info("FAMD analysis complete")
 

--- a/phase4_mca.py
+++ b/phase4_mca.py
@@ -5,8 +5,16 @@ import argparse
 import logging
 from pathlib import Path
 
-from phase4v2 import run_mca, export_mca_results
-from standalone_utils import prepare_active_dataset
+from phase4v2 import (
+    load_data,
+    prepare_data,
+    select_variables,
+    sanity_check,
+    handle_missing_values,
+    segment_data,
+    run_mca,
+    export_mca_results,
+)
 
 
 def main() -> None:
@@ -19,7 +27,14 @@ def main() -> None:
     logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
     out_dir = Path(args.output) / "MCA"
 
-    df_active, quant_vars, qual_vars = prepare_active_dataset(args.input, out_dir)
+    df_raw = load_data(args.input)
+    df_clean = prepare_data(df_raw)
+    df_active_tmp, quant_vars, qual_vars = select_variables(df_clean)
+    quant_vars, qual_vars = sanity_check(df_active_tmp, quant_vars, qual_vars)
+    df_active = df_active_tmp[quant_vars + qual_vars]
+    df_active = handle_missing_values(df_active, quant_vars, qual_vars)
+    segment_data(df_active, qual_vars, out_dir)
+    df_full = df_clean.loc[df_active.index]
 
     model, inertia, rows, cols, contrib = run_mca(
         df_active,
@@ -29,7 +44,15 @@ def main() -> None:
         n_components=args.n_components,
     )
 
-    export_mca_results(model, inertia, rows, cols, out_dir, qual_vars, df_active=df_active)
+    export_mca_results(
+        model,
+        inertia,
+        rows,
+        cols,
+        out_dir,
+        qual_vars,
+        df_active=df_full,
+    )
     logging.info("MCA analysis complete")
 
 

--- a/phase4_mfa.py
+++ b/phase4_mfa.py
@@ -5,8 +5,16 @@ import argparse
 import logging
 from pathlib import Path
 
-from phase4v2 import run_mfa, export_mfa_results
-from standalone_utils import prepare_active_dataset
+from phase4v2 import (
+    load_data,
+    prepare_data,
+    select_variables,
+    sanity_check,
+    handle_missing_values,
+    segment_data,
+    run_mfa,
+    export_mfa_results,
+)
 
 
 def main() -> None:
@@ -19,7 +27,14 @@ def main() -> None:
     logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
     out_dir = Path(args.output) / "MFA"
 
-    df_active, quant_vars, qual_vars = prepare_active_dataset(args.input, out_dir)
+    df_raw = load_data(args.input)
+    df_clean = prepare_data(df_raw)
+    df_active_tmp, quant_vars, qual_vars = select_variables(df_clean)
+    quant_vars, qual_vars = sanity_check(df_active_tmp, quant_vars, qual_vars)
+    df_active = df_active_tmp[quant_vars + qual_vars]
+    df_active = handle_missing_values(df_active, quant_vars, qual_vars)
+    segment_data(df_active, qual_vars, out_dir)
+    df_full = df_clean.loc[df_active.index]
 
     model, rows = run_mfa(
         df_active,
@@ -29,7 +44,14 @@ def main() -> None:
         n_components=args.n_components,
     )
 
-    export_mfa_results(model, rows, out_dir, quant_vars, qual_vars, df_active=df_active)
+    export_mfa_results(
+        model,
+        rows,
+        out_dir,
+        quant_vars,
+        qual_vars,
+        df_active=df_full,
+    )
     logging.info("MFA analysis complete")
 
 

--- a/phase4_pca.py
+++ b/phase4_pca.py
@@ -5,8 +5,16 @@ import argparse
 import logging
 from pathlib import Path
 
-from phase4v2 import run_pca, export_pca_results
-from standalone_utils import prepare_active_dataset
+from phase4v2 import (
+    load_data,
+    prepare_data,
+    select_variables,
+    sanity_check,
+    handle_missing_values,
+    segment_data,
+    run_pca,
+    export_pca_results,
+)
 
 
 def main() -> None:
@@ -19,7 +27,14 @@ def main() -> None:
     logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
     out_dir = Path(args.output) / "PCA"
 
-    df_active, quant_vars, qual_vars = prepare_active_dataset(args.input, out_dir)
+    df_raw = load_data(args.input)
+    df_clean = prepare_data(df_raw)
+    df_active_tmp, quant_vars, qual_vars = select_variables(df_clean)
+    quant_vars, qual_vars = sanity_check(df_active_tmp, quant_vars, qual_vars)
+    df_active = df_active_tmp[quant_vars + qual_vars]
+    df_active = handle_missing_values(df_active, quant_vars, qual_vars)
+    segment_data(df_active, qual_vars, out_dir)
+    df_full = df_clean.loc[df_active.index]
 
     model, inertia, rows, cols, contrib = run_pca(
         df_active,
@@ -29,7 +44,15 @@ def main() -> None:
         n_components=args.n_components,
     )
 
-    export_pca_results(model, inertia, rows, cols, out_dir, quant_vars, df_active=df_active)
+    export_pca_results(
+        model,
+        inertia,
+        rows,
+        cols,
+        out_dir,
+        quant_vars,
+        df_active=df_full,
+    )
     logging.info("PCA analysis complete")
 
 

--- a/phase4_pcamix.py
+++ b/phase4_pcamix.py
@@ -5,8 +5,16 @@ import argparse
 import logging
 from pathlib import Path
 
-from phase4v2 import run_pcamix, export_pcamix_results
-from standalone_utils import prepare_active_dataset
+from phase4v2 import (
+    load_data,
+    prepare_data,
+    select_variables,
+    sanity_check,
+    handle_missing_values,
+    segment_data,
+    run_pcamix,
+    export_pcamix_results,
+)
 
 
 def main() -> None:
@@ -19,7 +27,14 @@ def main() -> None:
     logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
     out_dir = Path(args.output) / "PCAmix"
 
-    df_active, quant_vars, qual_vars = prepare_active_dataset(args.input, out_dir)
+    df_raw = load_data(args.input)
+    df_clean = prepare_data(df_raw)
+    df_active_tmp, quant_vars, qual_vars = select_variables(df_clean)
+    quant_vars, qual_vars = sanity_check(df_active_tmp, quant_vars, qual_vars)
+    df_active = df_active_tmp[quant_vars + qual_vars]
+    df_active = handle_missing_values(df_active, quant_vars, qual_vars)
+    segment_data(df_active, qual_vars, out_dir)
+    df_full = df_clean.loc[df_active.index]
 
     model, inertia, rows, cols = run_pcamix(
         df_active,
@@ -29,7 +44,16 @@ def main() -> None:
         n_components=args.n_components,
     )
 
-    export_pcamix_results(model, inertia, rows, cols, out_dir, quant_vars, qual_vars, df_active=df_active)
+    export_pcamix_results(
+        model,
+        inertia,
+        rows,
+        cols,
+        out_dir,
+        quant_vars,
+        qual_vars,
+        df_active=df_full,
+    )
     logging.info("PCAmix analysis complete")
 
 

--- a/phase4_phate.py
+++ b/phase4_phate.py
@@ -5,8 +5,16 @@ import argparse
 import logging
 from pathlib import Path
 
-from phase4v2 import run_phate, export_phate_results
-from standalone_utils import prepare_active_dataset
+from phase4v2 import (
+    load_data,
+    prepare_data,
+    select_variables,
+    sanity_check,
+    handle_missing_values,
+    segment_data,
+    run_phate,
+    export_phate_results,
+)
 
 
 def main() -> None:
@@ -21,7 +29,14 @@ def main() -> None:
     logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
     out_dir = Path(args.output) / "PHATE"
 
-    df_active, quant_vars, qual_vars = prepare_active_dataset(args.input, out_dir)
+    df_raw = load_data(args.input)
+    df_clean = prepare_data(df_raw)
+    df_active_tmp, quant_vars, qual_vars = select_variables(df_clean)
+    quant_vars, qual_vars = sanity_check(df_active_tmp, quant_vars, qual_vars)
+    df_active = df_active_tmp[quant_vars + qual_vars]
+    df_active = handle_missing_values(df_active, quant_vars, qual_vars)
+    segment_data(df_active, qual_vars, out_dir)
+    df_full = df_clean.loc[df_active.index]
 
     op, emb = run_phate(
         df_active,
@@ -34,7 +49,7 @@ def main() -> None:
     )
 
     if op is not None:
-        export_phate_results(emb, df_active, out_dir)
+        export_phate_results(emb, df_full, out_dir)
     logging.info("PHATE analysis complete")
 
 

--- a/phase4_tsne.py
+++ b/phase4_tsne.py
@@ -5,8 +5,17 @@ import argparse
 import logging
 from pathlib import Path
 
-from phase4v2 import run_famd, run_tsne, export_tsne_results
-from standalone_utils import prepare_active_dataset
+from phase4v2 import (
+    load_data,
+    prepare_data,
+    select_variables,
+    sanity_check,
+    handle_missing_values,
+    segment_data,
+    run_famd,
+    run_tsne,
+    export_tsne_results,
+)
 
 
 def main() -> None:
@@ -19,7 +28,14 @@ def main() -> None:
     logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
     out_dir = Path(args.output) / "TSNE"
 
-    df_active, quant_vars, qual_vars = prepare_active_dataset(args.input, out_dir)
+    df_raw = load_data(args.input)
+    df_clean = prepare_data(df_raw)
+    df_active_tmp, quant_vars, qual_vars = select_variables(df_clean)
+    quant_vars, qual_vars = sanity_check(df_active_tmp, quant_vars, qual_vars)
+    df_active = df_active_tmp[quant_vars + qual_vars]
+    df_active = handle_missing_values(df_active, quant_vars, qual_vars)
+    segment_data(df_active, qual_vars, out_dir)
+    df_full = df_clean.loc[df_active.index]
 
     famd_model, inertia, rows, cols, contrib = run_famd(df_active, quant_vars, qual_vars)
 
@@ -30,7 +46,7 @@ def main() -> None:
         perplexity=args.perplexity,
     )
 
-    export_tsne_results(tsne_df, df_active, out_dir, metrics)
+    export_tsne_results(tsne_df, df_full, out_dir, metrics)
     logging.info("t-SNE analysis complete")
 
 

--- a/phase4_umap.py
+++ b/phase4_umap.py
@@ -5,8 +5,16 @@ import argparse
 import logging
 from pathlib import Path
 
-from phase4v2 import run_umap, export_umap_results
-from standalone_utils import prepare_active_dataset
+from phase4v2 import (
+    load_data,
+    prepare_data,
+    select_variables,
+    sanity_check,
+    handle_missing_values,
+    segment_data,
+    run_umap,
+    export_umap_results,
+)
 
 
 def main() -> None:
@@ -22,7 +30,14 @@ def main() -> None:
     logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
     out_dir = Path(args.output) / "UMAP"
 
-    df_active, quant_vars, qual_vars = prepare_active_dataset(args.input, out_dir)
+    df_raw = load_data(args.input)
+    df_clean = prepare_data(df_raw)
+    df_active_tmp, quant_vars, qual_vars = select_variables(df_clean)
+    quant_vars, qual_vars = sanity_check(df_active_tmp, quant_vars, qual_vars)
+    df_active = df_active_tmp[quant_vars + qual_vars]
+    df_active = handle_missing_values(df_active, quant_vars, qual_vars)
+    segment_data(df_active, qual_vars, out_dir)
+    df_full = df_clean.loc[df_active.index]
 
     model, emb = run_umap(
         df_active,
@@ -35,7 +50,7 @@ def main() -> None:
         metric=args.metric,
     )
 
-    export_umap_results(emb, df_active, out_dir)
+    export_umap_results(emb, df_full, out_dir)
     logging.info("UMAP analysis complete")
 
 

--- a/phase4v2.py
+++ b/phase4v2.py
@@ -49,7 +49,7 @@ CONFIG = {
 
 # Principal CRM segmentation columns used to generate variant scatters
 SEGMENT_COLUMNS = [
-    "Catégories",
+    "Catégorie",
     "Entité opérationnelle",
     "Pilier",
     "Sous-catégorie",


### PR DESCRIPTION
## Summary
- reload the full cleaned dataset in each standalone phase4 script
- keep all segmentation columns so plots include `Catégorie`
- pass the full dataset to export functions for correct segmentation scatters

## Testing
- `python test_run_famd.py`
- `python test_run_pacmap.py` (library missing warning is expected)
- `python test_run_pcamix.py`
- `python test_run_phate.py`
