### PR TITLE
Fix variable selection for non-string columns

### DIFF
--- a/data_processing.py
+++ b/data_processing.py
@@ -127,7 +127,7 @@ def select_variables(
             exclude.add(col)
         elif (
             df[col].dtype == object
-            and df[col].str.len().mean() > 50
+            and df[col].astype(str).str.len().mean() > 50
             and df[col].nunique() > 20
         ):
             exclude.add(col)


### PR DESCRIPTION
## Summary
- avoid `.str` on non-string data when checking for long text columns

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(no tests collected)*