### PR TITLE
Robust factor methods and MCA missing values test

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,5 +139,13 @@ python fine_tune_mfa.py --config config_mfa.yaml
 ```
 
 The script exports metrics for each configuration and saves the best model (by
-silhouette and Calinski–Harabasz indices) in the configured output directory.
 
+## Running tests
+
+After installing the requirements (or using `setup.sh` in a Codex environment), run:
+
+```bash
+pytest
+```
+
+to execute the automated test suite.

--- a/tests/test_famd.py
+++ b/tests/test_famd.py
@@ -1,0 +1,45 @@
+import pytest
+import ast
+import pandas as pd
+import prince
+from sklearn.preprocessing import StandardScaler
+import logging
+import numpy as np
+from typing import List, Optional, Tuple
+
+
+def load_run_famd(path='phase4v2.py'):
+    """Load only the run_famd function from the given file without executing the rest."""
+    source = open(path, 'r', encoding='utf-8').read()
+    module = ast.parse(source, filename=path)
+    namespace = {
+        'pd': pd,
+        'prince': prince,
+        'StandardScaler': StandardScaler,
+        'logging': logging,
+        'np': np,
+        'List': List,
+        'Optional': Optional,
+        'Tuple': Tuple,
+    }
+    for node in module.body:
+        if isinstance(node, ast.FunctionDef) and node.name in {'get_explained_inertia', 'run_famd'}:
+            func_code = ast.get_source_segment(source, node)
+            exec(compile(func_code, path, 'exec'), namespace)
+    if 'run_famd' in namespace:
+        return namespace['run_famd']
+    raise RuntimeError('run_famd not found')
+
+
+def test_run_famd_basic():
+    run_famd = load_run_famd()
+    df = pd.DataFrame({
+        'num1': [1, 2, 3, 4, 5],
+        'num2': [5, 4, 3, 2, 1],
+        'cat1': ['a', 'b', 'a', 'b', 'a']
+    })
+    famd, inertia, rows, cols, contrib = run_famd(df, ['num1', 'num2'], ['cat1'], n_components=2)
+    assert rows.shape == (5, 2)
+    assert cols.shape == (3, 2)
+    assert contrib.shape == (3, 2)
+    assert pytest.approx(float(inertia.sum()), rel=1e-6) == 1.0

--- a/tests/test_mca.py
+++ b/tests/test_mca.py
@@ -1,0 +1,13 @@
+import pandas as pd
+import numpy as np
+from block4_factor_methods import run_mca
+
+
+def test_run_mca_handles_missing():
+    df = pd.DataFrame({
+        "cat1": ["a", "b", np.nan, "c", np.inf],
+        "cat2": ["x", np.inf, "y", "x", "y"],
+    })
+    result = run_mca(df, ["cat1", "cat2"])
+    emb = result["embeddings"]
+    assert emb.shape[0] == len(df)

--- a/tests/test_pacmap.py
+++ b/tests/test_pacmap.py
@@ -1,0 +1,45 @@
+import ast
+import pandas as pd
+import numpy as np
+from sklearn.preprocessing import StandardScaler, OneHotEncoder
+import logging
+from pathlib import Path
+from typing import List, Optional, Tuple, Sequence, Any
+import pytest
+
+
+def load_run_pacmap(path='phase4v2.py'):
+    """Load run_pacmap function from the given file without executing the rest."""
+    source = open(path, 'r', encoding='utf-8').read()
+    module = ast.parse(source, filename=path)
+    namespace = {
+        'pd': pd,
+        'np': np,
+        'logging': logging,
+        'StandardScaler': StandardScaler,
+        'OneHotEncoder': OneHotEncoder,
+        'List': List,
+        'Optional': Optional,
+        'Tuple': Tuple,
+        'Sequence': Sequence,
+        'Any': Any,
+        'Path': Path,
+        'pacmap': None,
+    }
+    for node in module.body:
+        if isinstance(node, ast.FunctionDef) and node.name == 'run_pacmap':
+            func_code = ast.get_source_segment(source, node)
+            exec(compile(func_code, path, 'exec'), namespace)
+    return namespace['run_pacmap']
+
+
+def test_run_pacmap_no_module():
+    run_pacmap = load_run_pacmap()
+    df = pd.DataFrame({
+        'num1': [1, 2, 3],
+        'num2': [3, 2, 1],
+        'cat1': ['a', 'b', 'a']
+    })
+    model, emb = run_pacmap(df, ['num1', 'num2'], ['cat1'], Path('ignore'))
+    assert model is None
+    assert emb.empty

--- a/tests/test_pcamix.py
+++ b/tests/test_pcamix.py
@@ -1,0 +1,56 @@
+import ast
+import pandas as pd
+import prince
+from sklearn.preprocessing import StandardScaler
+import logging
+import numpy as np
+import matplotlib.pyplot as plt
+from pathlib import Path
+from typing import List, Optional, Tuple
+import pytest
+
+
+def load_run_pcamix(path='phase4v2.py'):
+    """Load run_pcamix function from file without executing rest."""
+    source = open(path, 'r', encoding='utf-8').read()
+    module = ast.parse(source, filename=path)
+    namespace = {
+        'pd': pd,
+        'prince': prince,
+        'StandardScaler': StandardScaler,
+        'logging': logging,
+        'np': np,
+        'plt': plt,
+        'List': List,
+        'Optional': Optional,
+        'Tuple': Tuple,
+        'Path': Path,
+    }
+    for node in module.body:
+        if isinstance(node, ast.FunctionDef) and node.name in {'get_explained_inertia', 'run_pcamix'}:
+            func_code = ast.get_source_segment(source, node)
+            exec(compile(func_code, path, 'exec'), namespace)
+    if 'run_pcamix' in namespace:
+        return namespace['run_pcamix']
+    raise RuntimeError('run_pcamix not found')
+
+
+def test_run_pcamix_basic(tmp_path: Path):
+    run_pcamix = load_run_pcamix()
+    df = pd.DataFrame({
+        'num1': [1, 2, 3, 4, 5],
+        'num2': [5, 4, 3, 2, 1],
+        'cat1': ['a', 'b', 'a', 'b', 'a']
+    })
+    model, inertia, rows, cols = run_pcamix(
+        df,
+        ['num1', 'num2'],
+        ['cat1'],
+        output_dir=tmp_path,
+        n_components=None,
+        optimize=False,
+    )
+    assert rows.shape[0] == 5
+    assert rows.shape[1] == cols.shape[1]
+    assert cols.shape[0] == 3
+    assert pytest.approx(float(inertia.sum()), rel=1e-6) == 1.0

--- a/tests/test_phate.py
+++ b/tests/test_phate.py
@@ -1,0 +1,52 @@
+import ast
+import pandas as pd
+import logging
+import numpy as np
+from pathlib import Path
+from sklearn.preprocessing import StandardScaler, OneHotEncoder
+from typing import List, Tuple, Any
+import phate
+import pytest
+
+
+def load_run_phate(path="phase4v2.py"):
+    """Load run_phate function from file without executing rest."""
+    source = open(path, "r", encoding="utf-8").read()
+    module = ast.parse(source, filename=path)
+    namespace = {
+        "pd": pd,
+        "StandardScaler": StandardScaler,
+        "OneHotEncoder": OneHotEncoder,
+        "logging": logging,
+        "np": np,
+        "phate": phate,
+        "List": List,
+        "Tuple": Tuple,
+        "Any": Any,
+        "Path": Path,
+    }
+    for node in module.body:
+        if isinstance(node, ast.FunctionDef) and node.name == "run_phate":
+            func_code = ast.get_source_segment(source, node)
+            exec(compile(func_code, path, "exec"), namespace)
+    if "run_phate" in namespace:
+        return namespace["run_phate"]
+    raise RuntimeError("run_phate not found")
+
+
+def test_run_phate_basic(tmp_path: Path):
+    run_phate = load_run_phate()
+    df = pd.DataFrame({
+        "num1": [1, 2, 3, 4, 5],
+        "num2": [5, 4, 3, 2, 1],
+        "cat1": ["a", "b", "a", "b", "a"],
+    })
+    op, coords = run_phate(
+        df,
+        ["num1", "num2"],
+        ["cat1"],
+        tmp_path,
+        n_components=2,
+    )
+    assert coords.shape == (5, 2)
+    assert op is not None


### PR DESCRIPTION
## Summary
- validate MCA input to avoid NaN/Inf
- compute inertia in a version independent way for MCA, FAMD and MFA
- test MCA on a dataframe containing NaNs and infinities

## Testing
- `pytest -q`