### PR TITLE
Fix FAMD with mixed datetime columns

### DIFF
--- a/block4_factor_methods.py
+++ b/block4_factor_methods.py
@@ -130,7 +130,11 @@ def run_famd(
         index=df_active.index,
         columns=quant_vars,
     )
-    df_cat = df_active[qual_vars].astype("category")
+    df_cat = df_active[qual_vars].copy()
+    for col in df_cat.columns:
+        if pd.api.types.is_datetime64_any_dtype(df_cat[col]):
+            df_cat[col] = df_cat[col].dt.strftime("%Y-%m-%d")
+        df_cat[col] = df_cat[col].astype("category")
     df_mix = pd.concat([df_quanti, df_cat], axis=1)
     df_mix.replace([np.inf, -np.inf], np.nan, inplace=True)
     if df_mix.isna().any().any():

--- a/data_processing.py
+++ b/data_processing.py
@@ -147,6 +147,8 @@ def select_variables(
 
     final_qual: List[str] = []
     for col in qual_vars:
+        if pd.api.types.is_datetime64_any_dtype(df[col]):
+            df[col] = df[col].dt.strftime("%Y-%m-%d")
         df[col] = df[col].astype("category")
         counts = df[col].value_counts(dropna=False)
         rares = counts[counts < min_modalite_freq].index

--- a/phase4v2.py
+++ b/phase4v2.py
@@ -2006,10 +2006,13 @@ def run_famd(
     )
 
     # 2) Assemblage du DataFrame mixte (quantitatif réduit + qualitatif brut)
-    df_for_famd = pd.concat(
-        [df_quanti_scaled, df_active[qual_vars].astype('category')],
-        axis=1
-    )
+    df_cat = df_active[qual_vars].copy()
+    for col in df_cat.columns:
+        if pd.api.types.is_datetime64_any_dtype(df_cat[col]):
+            df_cat[col] = df_cat[col].dt.strftime("%Y-%m-%d")
+        df_cat[col] = df_cat[col].astype("category")
+
+    df_for_famd = pd.concat([df_quanti_scaled, df_cat], axis=1)
     if df_for_famd.isnull().any().any():
         logger.error("Des valeurs manquantes subsistent dans df_for_famd. Corriger avant FAMD.")
         raise ValueError("NA détectés dans df_for_famd")

--- a/tests/test_famd.py
+++ b/tests/test_famd.py
@@ -43,3 +43,15 @@ def test_run_famd_basic():
     assert cols.shape == (3, 2)
     assert contrib.shape == (3, 2)
     assert pytest.approx(float(inertia.sum()), rel=1e-6) == 1.0
+
+
+def test_run_famd_with_datetimes():
+    run_famd = load_run_famd()
+    df = pd.DataFrame({
+        'num': [1, 2, 3, 4],
+        'date': pd.to_datetime(['2020-01-01', '2020-01-02', '2020-01-03', '2020-01-04']),
+        'cat': ['a', 'b', 'a', 'b'],
+    })
+    famd, inertia, rows, cols, contrib = run_famd(df, ['num'], ['date', 'cat'], n_components=2)
+    assert rows.shape[0] == 4
+


### PR DESCRIPTION
## Summary
- handle datetime columns in `select_variables`
- coerce datetimes to strings before running FAMD
- test FAMD with datetime categories

## Testing
- `pytest -q`