### PR TITLE
Improve UMAP CPU usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,9 @@ analyses. UMAP accepts several parameters in `config.yaml`, including
 
 ### UMAP warnings
 
-UMAP emits a warning when `random_state` is provided while using multiple
-threads. The provided configuration sets `n_jobs: 1` whenever a seed is used to
-avoid this warning and keep results reproducible. You can remove the seed if you
-prefer parallelism over determinism.
+UMAP runs in parallel by default (`n_jobs: -1`). If you set `random_state` for
+reproducibility, the library falls back to a single thread and prints a
+warning. Remove the seed if maximum CPU usage is preferred.
 
 ## Running `phase4v3.py`
 

--- a/config.yaml
+++ b/config.yaml
@@ -22,10 +22,10 @@ pca: {}
 mca: {}
 pcamix: {}
 umap:
-  # For reproducibility, random_state is set. UMAP will force n_jobs to 1 in
-  # this case, preventing a warning from the library.
-  random_state: 42
-  n_jobs: 1
+  # Use all CPU cores by default. Set `random_state` if you need
+  # reproducibility; UMAP will then run single-threaded.
+  random_state: null
+  n_jobs: -1
   metric: euclidean
 tsne: {}
 phate:

--- a/dim_reduction.py
+++ b/dim_reduction.py
@@ -31,12 +31,33 @@ def run_all_factor_methods(
     return results
 
 
-def run_all_nonlin(df_active: Any) -> Dict[str, Dict[str, Any]]:
+def run_all_nonlin(
+    df_active: Any,
+    *,
+    umap_params: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Dict[str, Any]]:
     """Run UMAP, PHATE and PaCMAP on the given dataset."""
+
     results: Dict[str, Dict[str, Any]] = {}
-    for name, func in (("UMAP", run_umap), ("PHATE", run_phate), ("PACMAP", run_pacmap)):
+
+    allowed_umap_keys = {
+        "n_components",
+        "n_neighbors",
+        "min_dist",
+        "random_state",
+        "n_jobs",
+    }
+    filtered_umap = {
+        k: v for k, v in (umap_params or {}).items() if k in allowed_umap_keys
+    }
+
+    for name, func, params in [
+        ("UMAP", run_umap, filtered_umap),
+        ("PHATE", run_phate, {}),
+        ("PACMAP", run_pacmap, {}),
+    ]:
         try:
-            results[name] = func(df_active)
+            results[name] = func(df_active, **params)
         except Exception as exc:  # pragma: no cover - missing deps
             results[name] = {"error": str(exc)}
     return results

--- a/nonlinear_methods.py
+++ b/nonlinear_methods.py
@@ -56,7 +56,8 @@ def run_umap(
     n_components: int = 2,
     n_neighbors: int = 15,
     min_dist: float = 0.1,
-    random_state: int | None = 42,
+    random_state: int | None = None,
+    n_jobs: int = -1,
 ) -> Dict[str, Any]:
     """Run UMAP on ``df_active`` and return embeddings with runtime."""
 
@@ -66,11 +67,19 @@ def run_umap(
     X = _to_numeric_matrix(df_active)
 
     start = time.time()
+    if random_state is not None and n_jobs not in (None, 1):
+        logging.getLogger(__name__).warning(
+            "random_state is set (%s): forcing n_jobs=1 for reproducibility",
+            random_state,
+        )
+        n_jobs = 1
+
     reducer = umap.UMAP(
         n_components=n_components,
         n_neighbors=n_neighbors,
         min_dist=min_dist,
         random_state=random_state,
+        n_jobs=n_jobs,
     )
     embedding = reducer.fit_transform(X)
     runtime = time.time() - start

--- a/phase4v3.py
+++ b/phase4v3.py
@@ -98,7 +98,10 @@ def main() -> None:
         qual_vars,
         groups=config.get("mfa_groups"),
     )
-    nonlin_results = run_all_nonlin(df_active)
+    nonlin_results = run_all_nonlin(
+        df_active,
+        umap_params=config.get("umap", {}),
+    )
 
     # ------------------------------------------------------------------
     # Optional cross-validation and temporal tests


### PR DESCRIPTION
## Summary
- allow UMAP to run on all cores
- accept UMAP parameters when running nonlinear reductions
- document updated parallelism behaviour
- default config now leaves the seed unset and uses all CPUs

## Testing
- `pytest -q`