### PR TITLE
Disable seeds in cross validation

### DIFF
--- a/block9_unsupervised_cv.py
+++ b/block9_unsupervised_cv.py
@@ -69,11 +69,11 @@ def _umap_distance_diff(train: pd.DataFrame, test: pd.DataFrame) -> float:
     cat_cols_t = [c for c in test.columns if c not in num_cols_t]
     X_test = _prepare_matrix(test, num_cols_t, cat_cols_t)
 
-    reducer = umap.UMAP(random_state=0)
+    reducer = umap.UMAP(n_jobs=-1, random_state=None)
     reducer.fit(X_train)
     proj_test = reducer.transform(X_test)
 
-    reducer2 = umap.UMAP(random_state=0)
+    reducer2 = umap.UMAP(n_jobs=-1, random_state=None)
     emb_test = reducer2.fit_transform(X_test)
 
     d1 = pairwise_distances(proj_test)
@@ -118,7 +118,7 @@ def unsupervised_cv_and_temporal_tests(
     if n_splits < 2:
         n_splits = 2
 
-    kf = KFold(n_splits=n_splits, shuffle=True, random_state=0)
+    kf = KFold(n_splits=n_splits, shuffle=True)
     pca_sims: list[float] = []
     umap_diffs: list[float] = []
     for train_idx, test_idx in kf.split(df_active):

--- a/dim_reduction.py
+++ b/dim_reduction.py
@@ -24,7 +24,7 @@ def run_all_factor_methods(
     results = {
         "PCA": run_pca(df_active, quant_vars),
         "MCA": run_mca(df_active, qual_vars),
-        "FAMD": run_famd(df_active, quant_vars, qual_vars),
+        # "FAMD": run_famd(df_active, quant_vars, qual_vars),  # temporarily disabled
     }
     if groups is not None:
         results["MFA"] = run_mfa(df_active, groups)

--- a/nonlinear_methods.py
+++ b/nonlinear_methods.py
@@ -68,12 +68,6 @@ def run_umap(
     X = _to_numeric_matrix(df_active)
 
     start = time.time()
-    if random_state is not None and n_jobs not in (None, 1):
-        logging.getLogger(__name__).warning(
-            "random_state is set (%s): forcing n_jobs=1 for reproducibility",
-            random_state,
-        )
-        n_jobs = 1
 
     reducer = umap.UMAP(
         n_components=n_components,
@@ -108,7 +102,7 @@ def run_phate(
     n_components: int = 2,
     k: int = 15,
     a: int = 40,
-    random_state: int | None = 42,
+    random_state: int | None = None,
 ) -> Dict[str, Any]:
     """Run PHATE on ``df_active`` and return embeddings with runtime."""
 

--- a/phase4v2.py
+++ b/phase4v2.py
@@ -536,7 +536,7 @@ def handle_missing_values(
     if df.isna().any().any():
         logger.error("Des NA demeurent dans df après traitement")
     else:
-        logger.info("DataFrame sans NA prêt pour FAMD")
+        logger.info("DataFrame sans NA prêt")
 
     return df
 
@@ -1258,8 +1258,8 @@ def run_umap(
         n_neighbors: Optional[int] = None,
         min_dist: Optional[float] = None,
         n_components: int = 2,
-        random_state: int | None = 42,
-        n_jobs: int | None = None,
+        random_state: int | None = None,
+        n_jobs: int | None = -1,
         metric: str = "euclidean",
         optimize: bool = False,
 ) -> Tuple[umap.UMAP, pd.DataFrame]:
@@ -1276,10 +1276,8 @@ def run_umap(
         min_dist: Distance minimale UMAP.
         n_components: Dimension de sortie (2 ou 3).
         random_state: Graine pour reproductibilité. ``None`` pour laisser
-            UMAP utiliser le parallélisme.
-        n_jobs: Nombre de threads UMAP. Si ``random_state`` est défini et
-            ``n_jobs`` n'est pas ``1``, la valeur sera forcée à ``1`` pour
-            éviter le warning de ``umap-learn``.
+            UMAP exploiter tous les cœurs.
+        n_jobs: Nombre de threads UMAP (``-1`` pour tous les cœurs).
         metric: Fonction de distance à utiliser ("euclidean", "manhattan",
             "cosine", ...).
         optimize: si ``True`` et que ``n_neighbors``/``min_dist`` ne sont pas
@@ -1315,21 +1313,12 @@ def run_umap(
     dist = min_dist if min_dist is not None else 0.1
 
     def _build_umap(nn, md):
-        nj = n_jobs
-        if random_state is not None:
-            if nj not in (None, 1):
-                logger.warning(
-                    "random_state défini (%s) : n_jobs=%s forcé à 1 pour garantir la reproductibilité",
-                    random_state,
-                    nj,
-                )
-            nj = -1
         return umap.UMAP(
             n_neighbors=nn,
             min_dist=md,
             n_components=n_components,
             random_state=random_state,
-            n_jobs=nj,
+            n_jobs=n_jobs,
             metric=metric,
         )
 
@@ -1453,7 +1442,7 @@ def run_pacmap(
         n_neighbors: Optional[int] = None,
         MN_ratio: float = 0.5,
         FP_ratio: float = 2.0,
-        random_state: int | None = 42,
+        random_state: int | None = None,
         optimize: bool = False,
         neighbor_grid: Sequence[int] | None = None,
 ) -> Tuple[Any | None, pd.DataFrame]:
@@ -1620,7 +1609,7 @@ def run_phate(
         n_components: int = 2,
         knn: int | str | None = None,
         t: int | str | None = "auto",
-        random_state: int | None = 42,
+        random_state: int | None = None,
         optimize: bool = False,
 ) -> Tuple[Any | None, pd.DataFrame]:
     """Exécute PHATE sur les données CRM pour détecter des trajectoires potentielles.
@@ -1629,8 +1618,7 @@ def run_phate(
     par exemple le passage de prospect à client fidèle. Il s'appuie sur un
     graphe de voisins et une diffusion pour préserver la structure globale. Les
     valeurs par défaut (``knn=5``, ``t='auto'``) conviennent généralement aux
-    volumes CRM ; ``n_jobs=-1`` exploite tous les cœurs et ``random_state=42``
-    assure la reproductibilité. Lorsque ``optimize`` est activé et qu'aucun
+    volumes CRM ; ``n_jobs=-1`` exploite tous les cœurs. Lorsque ``optimize`` est activé et qu'aucun
     ``knn`` n'est fourni, une recherche sur grille utilise le nombre de
     modalités des variables de segmentation comme valeurs candidates.
     """
@@ -3440,7 +3428,7 @@ def main() -> None:
     if df_active.isna().any().any():
         logger.error("Des NA demeurent dans df_active après traitement")
     else:
-        logger.info("DataFrame actif sans NA prêt pour FAMD")
+        logger.info("DataFrame actif sans NA prêt")
 
     segment_data(df_active, qual_vars, output_dir)
 
@@ -3448,6 +3436,9 @@ def main() -> None:
     n_jobs = int(config.get("n_jobs", 2))
     logger.info("Parallel executor using %d workers", n_jobs)
     methods = config.get("methods", [])
+    if "famd" in methods:
+        logger.info("FAMD step skipped")
+        methods.remove("famd")
     results: Dict[str, Dict[str, Any]] = {}
 
     start: Dict[str, float] = {}


### PR DESCRIPTION
## Summary
- avoid setting a seed when computing UMAP distances for CV
- remove the seed on the KFold splitter
- update log messages now that FAMD is skipped

## Testing
- `pytest -q`