### PR TITLE
Add non-linear dimension reduction utilities

### DIFF
--- a/nonlinear_methods.py
+++ b/nonlinear_methods.py
@@ -1,0 +1,224 @@
+"""Non-linear dimensionality reduction utilities.
+
+This module re-implements the UMAP, PHATE and PaCMAP wrappers that were
+previously scattered across several scripts. The functions are self-contained
+and do not depend on ``phase4v2.py`` or the fine-tuning scripts so that those
+files can be removed without breaking the pipeline.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, Dict, Optional, Tuple
+
+import numpy as np
+import pandas as pd
+from sklearn.preprocessing import OneHotEncoder, StandardScaler
+import umap
+
+try:  # optional dependencies
+    import phate  # type: ignore
+except Exception:  # pragma: no cover - optional dependency may not be present
+    phate = None
+
+try:
+    import pacmap  # type: ignore
+except Exception:  # pragma: no cover - optional dependency may not be present
+    pacmap = None
+
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _encode_mixed(df: pd.DataFrame) -> np.ndarray:
+    """Return a numeric matrix from ``df`` with scaling and one-hot encoding."""
+    if not isinstance(df, pd.DataFrame):
+        raise TypeError("df must be a pandas DataFrame")
+
+    numeric_cols = df.select_dtypes(include="number").columns.tolist()
+    cat_cols = df.select_dtypes(exclude="number").columns.tolist()
+
+    X_num = (
+        StandardScaler().fit_transform(df[numeric_cols]) if numeric_cols else np.empty((len(df), 0))
+    )
+
+    if cat_cols:
+        try:
+            enc = OneHotEncoder(sparse_output=False, handle_unknown="ignore")
+        except TypeError:  # pragma: no cover - older scikit-learn
+            enc = OneHotEncoder(sparse=False, handle_unknown="ignore")
+        X_cat = enc.fit_transform(df[cat_cols])
+    else:
+        X_cat = np.empty((len(df), 0))
+
+    if X_num.size and X_cat.size:
+        return np.hstack([X_num, X_cat])
+    if X_num.size:
+        return X_num
+    return X_cat
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def run_umap(
+    df_active: pd.DataFrame,
+    n_components: int = 2,
+    n_neighbors: int = 15,
+    min_dist: float = 0.1,
+    *,
+    metric: str = "euclidean",
+    random_state: Optional[int] = 42,
+) -> Dict[str, Any]:
+    """Run UMAP on ``df_active`` and return model and embeddings."""
+    start = time.perf_counter()
+    X = _encode_mixed(df_active)
+
+    reducer = umap.UMAP(
+        n_components=n_components,
+        n_neighbors=n_neighbors,
+        min_dist=min_dist,
+        metric=metric,
+        random_state=random_state,
+    )
+    embedding = reducer.fit_transform(X)
+    runtime = time.perf_counter() - start
+
+    cols = [f"UMAP{i + 1}" for i in range(n_components)]
+    emb_df = pd.DataFrame(embedding, index=df_active.index, columns=cols)
+
+    params = {
+        "n_components": n_components,
+        "n_neighbors": n_neighbors,
+        "min_dist": min_dist,
+        "metric": metric,
+    }
+    return {
+        "model": reducer,
+        "embeddings": emb_df,
+        "params": params,
+        "runtime_s": runtime,
+    }
+
+
+def run_phate(
+    df_active: pd.DataFrame,
+    n_components: int = 2,
+    k: int = 15,
+    a: int = 40,
+    *,
+    t: str | int = "auto",
+    random_state: Optional[int] = 42,
+) -> Dict[str, Any]:
+    """Run PHATE on ``df_active``.
+
+    Returns an empty result if PHATE is not installed.
+    """
+    if phate is None:
+        logger.warning("PHATE is not installed; skipping")
+        return {"model": None, "embeddings": pd.DataFrame(index=df_active.index), "params": {}}
+
+    start = time.perf_counter()
+    X = _encode_mixed(df_active)
+
+    op = phate.PHATE(
+        n_components=n_components,
+        knn=k,
+        decay=a,
+        t=t,
+        n_jobs=-1,
+        random_state=random_state,
+        verbose=False,
+    )
+    embedding = op.fit_transform(X)
+    runtime = time.perf_counter() - start
+
+    cols = [f"PHATE{i + 1}" for i in range(n_components)]
+    emb_df = pd.DataFrame(embedding, index=df_active.index, columns=cols)
+
+    params = {"n_components": n_components, "k": k, "a": a, "t": t}
+    return {"model": op, "embeddings": emb_df, "params": params, "runtime_s": runtime}
+
+
+def run_pacmap(
+    df_active: pd.DataFrame,
+    n_components: int = 2,
+    n_neighbors: int = 10,
+    *,
+    MN_ratio: float = 0.5,
+    FP_ratio: float = 2.0,
+    num_iters: Tuple[int, int, int] = (10, 10, 10),
+    random_state: Optional[int] = 42,
+) -> Dict[str, Any]:
+    """Run PaCMAP on ``df_active``.
+
+    If PaCMAP is unavailable or fails, ``model`` is ``None`` and the embeddings
+    DataFrame is empty.
+    """
+    if pacmap is None:
+        logger.warning("PaCMAP is not installed; skipping")
+        return {"model": None, "embeddings": pd.DataFrame(index=df_active.index), "params": {}}
+
+    start = time.perf_counter()
+    X = _encode_mixed(df_active)
+
+    try:
+        params = dict(
+            n_components=n_components,
+            n_neighbors=n_neighbors,
+            MN_ratio=MN_ratio,
+            FP_ratio=FP_ratio,
+            num_iters=num_iters,
+            random_state=random_state,
+            verbose=False,
+            apply_pca=True,
+        )
+        model = pacmap.PaCMAP(**params)
+        embedding = model.fit_transform(X)
+    except Exception as exc:  # pragma: no cover - rare runtime error
+        logger.warning("PaCMAP failed: %s", exc)
+        return {"model": None, "embeddings": pd.DataFrame(index=df_active.index), "params": {}}
+
+    runtime = time.perf_counter() - start
+    cols = [f"PACMAP{i + 1}" for i in range(n_components)]
+    emb_df = pd.DataFrame(embedding, index=df_active.index, columns=cols)
+    params.pop("verbose")
+    params.pop("apply_pca")
+    return {
+        "model": model,
+        "embeddings": emb_df,
+        "params": params,
+        "runtime_s": runtime,
+    }
+
+
+def run_all_nonlinear(df_active: pd.DataFrame) -> Dict[str, Dict[str, Any]]:
+    """Execute all non-linear methods on ``df_active`` and collect the results."""
+    results: Dict[str, Dict[str, Any]] = {}
+
+    try:
+        results["umap"] = run_umap(df_active)
+    except Exception as exc:  # pragma: no cover - unexpected runtime failure
+        logger.warning("UMAP failed: %s", exc)
+        results["umap"] = {"error": str(exc)}
+
+    try:
+        results["phate"] = run_phate(df_active)
+    except Exception as exc:  # pragma: no cover - unexpected runtime failure
+        logger.warning("PHATE failed: %s", exc)
+        results["phate"] = {"error": str(exc)}
+
+    try:
+        results["pacmap"] = run_pacmap(df_active)
+    except Exception as exc:  # pragma: no cover - unexpected runtime failure
+        logger.warning("PaCMAP failed: %s", exc)
+        results["pacmap"] = {"error": str(exc)}
+
+    return results
+

--- a/test_nonlinear_methods.py
+++ b/test_nonlinear_methods.py
@@ -1,0 +1,51 @@
+import pandas as pd
+import numpy as np
+
+from nonlinear_methods import run_umap, run_phate, run_pacmap, run_all_nonlinear
+
+
+def sample_df() -> pd.DataFrame:
+    return pd.DataFrame({
+        "num1": [1, 2, 3, 4, 5],
+        "num2": [5, 4, 3, 2, 1],
+        "cat": ["a", "b", "a", "b", "a"],
+    })
+
+
+def test_run_umap_basic():
+    df = sample_df()
+    res = run_umap(df, n_components=2, n_neighbors=3, min_dist=0.1)
+    assert res["embeddings"].shape == (len(df), 2)
+    assert res["params"]["n_neighbors"] == 3
+
+
+def test_run_phate_basic():
+    df = sample_df()
+    res = run_phate(df, n_components=2, k=3, a=10)
+    assert res["embeddings"].shape[0] == len(df)
+    assert res["embeddings"].shape[1] == 2
+
+
+def test_run_pacmap_basic():
+    df = sample_df()
+    # Avoid heavy numba compilation by mocking the pacmap dependency
+    import types
+    import nonlinear_methods as nl
+    original = nl.pacmap
+    try:
+        dummy = types.SimpleNamespace(
+            PaCMAP=lambda **kwargs: types.SimpleNamespace(
+                fit_transform=lambda X: np.zeros((len(X), 2))
+            )
+        )
+        nl.pacmap = dummy
+        res = nl.run_pacmap(df, n_components=2, n_neighbors=3)
+        assert res["embeddings"].shape == (len(df), 2)
+    finally:
+        nl.pacmap = original
+
+
+def test_run_all_nonlinear():
+    df = sample_df()
+    results = run_all_nonlinear(df)
+    assert set(results.keys()) >= {"umap", "phate", "pacmap"}


### PR DESCRIPTION
## Summary
- implement `nonlinear_methods.py` with UMAP, PHATE and PaCMAP wrappers
- include helper to preprocess mixed data and a convenience function
- add pytest suite `test_nonlinear_methods.py`

## Testing
- `pytest -q`