### PR TITLE
Fix correlation circle when only one axis available

### DIFF
--- a/test_generate_figures.py
+++ b/test_generate_figures.py
@@ -44,3 +44,33 @@ def test_generate_figures_basic():
     assert "umap_scatter_2d" in figs
     for f in figs.values():
         assert hasattr(f, "savefig")
+
+
+def test_generate_figures_missing_f2():
+    df = pd.DataFrame({
+        "num1": [1, 2, 3],
+        "num2": [4, 5, 6],
+        "cat": ["a", "b", "a"],
+    })
+
+    factor_results = {
+        "pca": {
+            "embeddings": pd.DataFrame(
+                [[0.1, 0.2], [0.0, -0.1], [0.2, 0.1]],
+                index=df.index,
+                columns=["F1", "F2"],
+            ),
+            "loadings": pd.DataFrame(
+                [[0.7], [0.1]],
+                index=["num1", "num2"],
+                columns=["F1"],
+            ),
+            "inertia": pd.Series([1.0], index=["F1"]),
+        }
+    }
+
+    figs = generate_figures(factor_results, {}, df, ["num1", "num2"], ["cat"])
+    # scatter plot should still be produced
+    assert "pca_scatter_2d" in figs
+    # correlation plot cannot be generated with a single axis
+    assert "pca_correlation" not in figs

--- a/visualization.py
+++ b/visualization.py
@@ -121,6 +121,12 @@ def plot_scatter_3d(
 def _extract_quant_coords(coords: pd.DataFrame, quant_vars: List[str]) -> pd.DataFrame:
     """Extract F1/F2 coordinates for quantitative variables if available."""
     cols = [c for c in ["F1", "F2"] if c in coords.columns]
+    if len(cols) < 2:
+        # fall back to the first available columns
+        extra = [c for c in coords.columns if c not in cols][: 2 - len(cols)]
+        cols.extend(extra)
+    if len(cols) < 2:
+        return pd.DataFrame(columns=["F1", "F2"])
     subset = coords.loc[[v for v in quant_vars if v in coords.index], cols]
     subset = subset.rename(columns={cols[0]: "F1", cols[1]: "F2"})
     return subset


### PR DESCRIPTION
## Summary
- handle datasets where factor analysis loadings only return a single axis
- add regression test for figure generation with a single loading column

## Testing
- `pytest -q`