### PR TITLE
Add cluster visualizations

### DIFF
--- a/test_generate_figures.py
+++ b/test_generate_figures.py
@@ -74,3 +74,27 @@ def test_generate_figures_missing_f2():
     assert "pca_scatter_2d" in figs
     # correlation plot cannot be generated with a single axis
     assert "pca_correlation" not in figs
+
+
+def test_generate_figures_clusters(tmp_path):
+    df = pd.DataFrame({
+        "num1": [1, 2, 3, 4],
+        "num2": [4, 3, 2, 1],
+        "cat": ["a", "b", "a", "b"],
+    })
+
+    factor_results = {
+        "pca": {
+            "embeddings": pd.DataFrame(
+                [[0.1, 0.2], [0.0, -0.1], [0.2, 0.1], [-0.2, -0.1]],
+                index=df.index,
+                columns=["F1", "F2"],
+            )
+        }
+    }
+
+    figs = generate_figures(factor_results, {}, df, ["num1", "num2"], ["cat"], cluster_k=2)
+    assert "pca_clusters" in figs
+    out = tmp_path / "cluster.png"
+    figs["pca_clusters"].savefig(out)
+    assert out.exists()


### PR DESCRIPTION
## Summary
- add `plot_cluster_scatter` helper to draw K-Means clusters
- extend `generate_figures` with optional `cluster_k` parameter
- create cluster plots for each method
- test cluster scatter generation

## Testing
- `pytest -q`