### PR TITLE
Add cluster visualizations

### DIFF
--- a/test_generate_figures.py
+++ b/test_generate_figures.py
@@ -5,7 +5,7 @@ matplotlib.use("Agg")
 from visualization import generate_figures
 
 
-def test_generate_figures_basic():
+def test_generate_figures_basic(tmp_path):
     df = pd.DataFrame({
         "num1": [1, 2, 3],
         "num2": [4, 5, 6],
@@ -38,7 +38,17 @@ def test_generate_figures_basic():
         }
     }
 
-    figs = generate_figures(factor_results, nonlin_results, df, ["num1", "num2"], ["cat"])
+    figs = generate_figures(
+        factor_results,
+        nonlin_results,
+        df,
+        ["num1", "num2"],
+        ["cat"],
+        output_dir=tmp_path,
+    )
+    assert (tmp_path / "pca" / "pca_scatter_2d.png").exists()
+    assert (tmp_path / "pca" / "pca_correlation.png").exists()
+    assert (tmp_path / "umap" / "umap_scatter_2d.png").exists()
     assert "pca_correlation" in figs
     assert "pca_scatter_2d" in figs
     assert "umap_scatter_2d" in figs
@@ -46,7 +56,7 @@ def test_generate_figures_basic():
         assert hasattr(f, "savefig")
 
 
-def test_generate_figures_missing_f2():
+def test_generate_figures_missing_f2(tmp_path):
     df = pd.DataFrame({
         "num1": [1, 2, 3],
         "num2": [4, 5, 6],
@@ -69,8 +79,46 @@ def test_generate_figures_missing_f2():
         }
     }
 
-    figs = generate_figures(factor_results, {}, df, ["num1", "num2"], ["cat"])
+    figs = generate_figures(
+        factor_results,
+        {},
+        df,
+        ["num1", "num2"],
+        ["cat"],
+        output_dir=tmp_path,
+    )
     # scatter plot should still be produced
     assert "pca_scatter_2d" in figs
     # correlation plot cannot be generated with a single axis
     assert "pca_correlation" not in figs
+
+
+def test_generate_figures_clusters(tmp_path):
+    df = pd.DataFrame({
+        "num1": [1, 2, 3, 4],
+        "num2": [4, 3, 2, 1],
+        "cat": ["a", "b", "a", "b"],
+    })
+
+    factor_results = {
+        "pca": {
+            "embeddings": pd.DataFrame(
+                [[0.1, 0.2], [0.0, -0.1], [0.2, 0.1], [-0.2, -0.1]],
+                index=df.index,
+                columns=["F1", "F2"],
+            )
+        }
+    }
+
+    figs = generate_figures(
+        factor_results,
+        {},
+        df,
+        ["num1", "num2"],
+        ["cat"],
+        output_dir=tmp_path,
+        cluster_k=2,
+    )
+    assert "pca_clusters" in figs
+    out = tmp_path / "pca" / "pca_clusters.png"
+    assert out.exists()

--- a/visualization.py
+++ b/visualization.py
@@ -6,10 +6,12 @@ import matplotlib
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 from mpl_toolkits.mplot3d import Axes3D  # noqa: F401
+from pathlib import Path
 import pandas as pd
 import seaborn as sns
 import numpy as np
 from typing import Dict, Any, List, Optional
+from sklearn.cluster import KMeans
 
 
 def plot_correlation_circle(coords: pd.DataFrame, title: str) -> plt.Figure:
@@ -118,6 +120,53 @@ def plot_scatter_3d(
     return fig
 
 
+def plot_cluster_scatter(
+    emb_df: pd.DataFrame, labels: np.ndarray, title: str
+) -> plt.Figure:
+    """Return a 2D scatter plot coloured by K-Means clusters.
+
+    Parameters
+    ----------
+    emb_df : pandas.DataFrame
+        Embedding coordinates with at least two columns.
+    labels : array-like
+        Cluster labels for each observation.
+    title : str
+        Title of the figure.
+    """
+    fig, ax = plt.subplots(figsize=(12, 6), dpi=200)
+    unique = np.unique(labels)
+    try:
+        cmap = matplotlib.colormaps.get_cmap("tab10")
+    except AttributeError:  # Matplotlib < 3.6
+        cmap = matplotlib.cm.get_cmap("tab10")
+    n_colors = cmap.N if hasattr(cmap, "N") else len(unique)
+    for i, lab in enumerate(unique):
+        mask = labels == lab
+        ax.scatter(
+            emb_df.loc[mask, emb_df.columns[0]],
+            emb_df.loc[mask, emb_df.columns[1]],
+            s=10,
+            alpha=0.7,
+            color=cmap(i % n_colors),
+            label=str(lab),
+        )
+        centroid = emb_df.loc[mask, emb_df.columns[:2]].mean().values
+        ax.scatter(
+            centroid[0],
+            centroid[1],
+            marker="x",
+            s=60,
+            color=cmap(i % n_colors),
+        )
+    ax.legend(title="cluster", bbox_to_anchor=(1.05, 1), loc="upper left")
+    ax.set_xlabel(emb_df.columns[0])
+    ax.set_ylabel(emb_df.columns[1])
+    ax.set_title(title)
+    fig.tight_layout()
+    return fig
+
+
 def _extract_quant_coords(coords: pd.DataFrame, quant_vars: List[str]) -> pd.DataFrame:
     """Extract F1/F2 coordinates for quantitative variables if available."""
     cols = [c for c in ["F1", "F2"] if c in coords.columns]
@@ -132,17 +181,72 @@ def _extract_quant_coords(coords: pd.DataFrame, quant_vars: List[str]) -> pd.Dat
     return subset
 
 
+def plot_scree(inertia: pd.Series, title: str) -> plt.Figure:
+    """Return a scree plot showing variance explained by each component."""
+    axes = range(1, len(inertia) + 1)
+    fig, ax = plt.subplots(figsize=(12, 6), dpi=200)
+    ax.bar(axes, inertia.values * 100, edgecolor="black")
+    ax.plot(axes, np.cumsum(inertia.values) * 100, "-o", color="orange")
+    ax.set_xlabel("Composante")
+    ax.set_ylabel("% Variance expliquée")
+    ax.set_title(title)
+    ax.set_xticks(list(axes))
+    fig.tight_layout()
+    return fig
+
+
+def plot_famd_contributions(contrib: pd.DataFrame, n: int = 10) -> plt.Figure:
+    """Return a bar plot of variable contributions to F1 and F2."""
+    if not {"F1", "F2"}.issubset(contrib.columns):
+        cols = contrib.columns[:2]
+        contrib = contrib.rename(columns={cols[0]: "F1", cols[1]: "F2"})
+    grouped: Dict[str, pd.Series] = {}
+    for idx in contrib.index:
+        var = idx.split("__", 1)[0]
+        grouped.setdefault(var, pd.Series(dtype=float))
+        grouped[var] = grouped[var].add(contrib.loc[idx, ["F1", "F2"]], fill_value=0)
+    df = pd.DataFrame(grouped).T.fillna(0)
+    df = df.sort_values(df.sum(axis=1).name if df.columns.size > 2 else 0, ascending=False)
+    df = df.iloc[:n]
+    fig, ax = plt.subplots(figsize=(12, 6), dpi=200)
+    df[["F1", "F2"]].plot(kind="bar", stacked=True, ax=ax)
+    ax.set_ylabel("% Contribution")
+    ax.set_title("Contribution des variables à F1/F2 – FAMD")
+    ax.legend(title="Axe")
+    fig.tight_layout()
+    return fig
+
+
 def generate_figures(
     factor_results: Dict[str, Dict[str, Any]],
     nonlin_results: Dict[str, Dict[str, Any]],
     df_active: pd.DataFrame,
     quant_vars: List[str],
     qual_vars: List[str],
+    output_dir: Optional[Path] = None,
+    *,
+    cluster_k: int = 3,
 ) -> Dict[str, plt.Figure]:
-    """Generate comparative figures for dimensionality reduction results."""
+    """Generate and optionally save comparative visualization figures.
+
+    Parameters
+    ----------
+    output_dir : Path or None, optional
+        Directory where figures will be saved.
+    cluster_k : int, default ``3``
+        Number of K-Means clusters for the additional scatter plots.
+    """
     color_var = _choose_color_var(df_active, qual_vars)
     figures: Dict[str, plt.Figure] = {}
     first_3d_done = False
+    out = Path(output_dir) if output_dir is not None else None
+
+    def _save(fig: plt.Figure, method: str, name: str) -> None:
+        if out is None:
+            return
+        sub = out / method.lower()
+        sub.mkdir(parents=True, exist_ok=True)
+        fig.savefig(sub / f"{name}.png")
 
     for method, res in factor_results.items():
         emb = res.get("embeddings")
@@ -154,13 +258,22 @@ def generate_figures(
                 f"Projection des affaires – {method.upper()}",
             )
             figures[f"{method}_scatter_2d"] = fig
+            _save(fig, method, f"{method}_scatter_2d")
+            km = KMeans(n_clusters=cluster_k, random_state=0)
+            labels = km.fit_predict(emb.iloc[:, :2].values)
+            title = f"Projection {method.upper()} – coloration par clusters (k={cluster_k})"
+            cfig = plot_cluster_scatter(emb.iloc[:, :2], labels, title)
+            figures[f"{method}_clusters"] = cfig
+            _save(cfig, method, f"{method}_clusters")
             if not first_3d_done and emb.shape[1] >= 3:
-                figures[f"{method}_scatter_3d"] = plot_scatter_3d(
+                fig3d = plot_scatter_3d(
                     emb.iloc[:, :3],
                     df_active,
                     color_var,
                     f"Projection 3D – {method.upper()}",
                 )
+                figures[f"{method}_scatter_3d"] = fig3d
+                _save(fig3d, method, f"{method}_scatter_3d")
                 first_3d_done = True
         coords = res.get("loadings")
         if coords is None:
@@ -171,7 +284,20 @@ def generate_figures(
                 var_pc = res.get("inertia")
                 pct = float(var_pc.iloc[:2].sum() * 100) if isinstance(var_pc, pd.Series) else float("nan")
                 title = f"{method.upper()} – cercle des corrélations (F1–F2)\nVariance {pct:.1f}%"
-                figures[f"{method}_correlation"] = plot_correlation_circle(qcoords, title)
+                fig_corr = plot_correlation_circle(qcoords, title)
+                figures[f"{method}_correlation"] = fig_corr
+                _save(fig_corr, method, f"{method}_correlation")
+        inertia = res.get("inertia")
+        if isinstance(inertia, pd.Series) and not inertia.empty:
+            fig_scree = plot_scree(inertia, f"Variance expliquée par composante – {method.upper()}")
+            figures[f"{method}_scree"] = fig_scree
+            _save(fig_scree, method, f"{method}_scree")
+        if method == "famd":
+            contrib = res.get("contributions")
+            if isinstance(contrib, pd.DataFrame) and not contrib.empty:
+                fig_contrib = plot_famd_contributions(contrib)
+                figures[f"{method}_contributions"] = fig_contrib
+                _save(fig_contrib, method, f"{method}_contributions")
 
     for method, res in nonlin_results.items():
         emb = res.get("embeddings")
@@ -183,13 +309,22 @@ def generate_figures(
                 f"Projection des affaires – {method.upper()}",
             )
             figures[f"{method}_scatter_2d"] = fig
+            _save(fig, method, f"{method}_scatter_2d")
+            km = KMeans(n_clusters=cluster_k, random_state=0)
+            labels = km.fit_predict(emb.iloc[:, :2].values)
+            title = f"Projection {method.upper()} – coloration par clusters (k={cluster_k})"
+            cfig = plot_cluster_scatter(emb.iloc[:, :2], labels, title)
+            figures[f"{method}_clusters"] = cfig
+            _save(cfig, method, f"{method}_clusters")
             if not first_3d_done and emb.shape[1] >= 3:
-                figures[f"{method}_scatter_3d"] = plot_scatter_3d(
+                fig3d = plot_scatter_3d(
                     emb.iloc[:, :3],
                     df_active,
                     color_var,
                     f"Projection 3D – {method.upper()}",
                 )
+                figures[f"{method}_scatter_3d"] = fig3d
+                _save(fig3d, method, f"{method}_scatter_3d")
                 first_3d_done = True
     return figures
 


### PR DESCRIPTION
## Summary
- add output directory support to `generate_figures`
- include scree and FAMD contribution plots
- generate K-Means cluster projections for each method
- verify file creation in tests

## Testing
- `pytest -q`
