### PR TITLE
Add missing-value test for prepare_data

### DIFF
--- a/test_prepare_data.py
+++ b/test_prepare_data.py
@@ -64,3 +64,26 @@ def test_prepare_data_flag_file(tmp_path: Path):
     cleaned = mod.prepare_data(df, exclude_lost=False, flagged_ids_path=flagged_path)
 
     assert list(cleaned["Code"]) == [1, 3]
+
+def test_prepare_data_imputes_missing_values():
+    mod = importlib.import_module("data_preparation")
+
+    df = pd.DataFrame(
+        {
+            "Code": [1, 2, 3],
+            "Date de début actualisée": ["2024-01-01"] * 3,
+            "Date de fin réelle": ["2024-01-02"] * 3,
+            "Total recette réalisé": [np.nan, "-5", "100"],
+            "Budget client estimé": [np.nan, 40, 60],
+            "Statut commercial": ["Gagné", "Gagné", "Gagné"],
+        }
+    )
+
+    cleaned = mod.prepare_data(df, exclude_lost=False)
+
+    num_cols = cleaned.select_dtypes(include=np.number).columns
+    assert not cleaned[num_cols].isna().any().any()
+
+    means = cleaned[num_cols.difference(["Code"])].mean()
+    assert np.allclose(means, 0, atol=1e-6)
+


### PR DESCRIPTION
## Summary
- extend prepare_data tests to check NaN imputation
- fix minor typo in the added test

## Testing
- `pytest -q`
