### PR TITLE
Improve dataset loading and tests

### DIFF
--- a/phase4v3.py
+++ b/phase4v3.py
@@ -55,6 +55,9 @@ except Exception:  # pragma: no cover - optional dependency may not be present
 
 from best_params import BEST_PARAMS
 
+# Global configuration updated by ``main`` when run as a script
+CONFIG: Dict[str, Any] = {}
+
 
 # ---------------------------------------------------------------------------
 # Data Loading & Preparation
@@ -99,8 +102,12 @@ def _load_data_dictionary(path: Optional[Path]) -> Dict[str, str]:
     return mapping
 
 
-def load_datasets(config: Dict[str, Any]) -> Dict[str, pd.DataFrame]:
-    """Load raw and cleaned datasets specified in ``config``."""
+def load_datasets(config: Optional[Dict[str, Any]] = None) -> Dict[str, pd.DataFrame]:
+    """Load raw and cleaned datasets specified in ``config`` or ``CONFIG``."""
+    if config is None:
+        config = CONFIG
+    if not isinstance(config, dict):
+        raise TypeError("config must be a dictionary")
     logger = logging.getLogger(__name__)
     if "input_file" not in config:
         raise ValueError("'input_file' missing from config")
@@ -120,6 +127,8 @@ def load_datasets(config: Dict[str, Any]) -> Dict[str, pd.DataFrame]:
         if mapping:
             df = df.rename(columns={c: mapping.get(c, c) for c in df.columns})
         return df
+
+    datasets["raw"] = _apply_mapping(datasets["raw"])
 
     for key, cfg_key in [
         ("phase1", "phase1_file"),

--- a/test_phase4v3.py
+++ b/test_phase4v3.py
@@ -5,27 +5,25 @@ import pandas as pd
 import pytest
 
 
-@pytest.fixture()
-def sample_files(tmp_path: Path):
-    raw = pd.DataFrame({
-        "Date Op": ["2024-01-01", "2024-02-01"],
-        "Total recette realise": ["1 000", "2 500"],
-        "Categorie": ["A", "B"],
-    })
+def _make_sample_config(tmp_path: Path) -> dict[str, str]:
+    raw = pd.DataFrame(
+        {
+            "Date Op": ["2024-01-01", "2024-02-01"],
+            "Total recette realise": ["1 000", "2 500"],
+            "Categorie": ["A", "B"],
+        }
+    )
     raw_path = tmp_path / "raw.csv"
     raw.to_csv(raw_path, index=False)
 
-    phase1 = raw.copy()
     phase1_path = tmp_path / "phase1.csv"
-    phase1.to_csv(phase1_path, index=False)
+    raw.to_csv(phase1_path, index=False)
 
-    phase2 = raw.iloc[:1]
     phase2_path = tmp_path / "phase2.csv"
-    phase2.to_csv(phase2_path, index=False)
+    raw.iloc[:1].to_csv(phase2_path, index=False)
 
-    phase3 = raw.copy()
     phase3_path = tmp_path / "phase3.csv"
-    phase3.to_csv(phase3_path, index=False)
+    raw.to_csv(phase3_path, index=False)
 
     return {
         "input_file": str(raw_path),
@@ -33,6 +31,26 @@ def sample_files(tmp_path: Path):
         "phase2_file": str(phase2_path),
         "phase3_file": str(phase3_path),
     }
+
+
+@pytest.fixture()
+def sample_files(tmp_path: Path) -> dict[str, str]:
+    return _make_sample_config(tmp_path)
+
+
+@pytest.fixture()
+def sample_files_with_dict(tmp_path: Path) -> dict[str, str]:
+    cfg = _make_sample_config(tmp_path)
+    mapping = pd.DataFrame(
+        {
+            "original": ["Date Op", "Total recette realise", "Categorie"],
+            "renamed": ["date", "recette", "categorie"],
+        }
+    )
+    dict_path = tmp_path / "dict.xlsx"
+    mapping.to_excel(dict_path, index=False)
+    cfg["data_dictionary"] = str(dict_path)
+    return cfg
 
 
 def test_load_datasets_types(sample_files):
@@ -44,6 +62,37 @@ def test_load_datasets_types(sample_files):
     assert pd.api.types.is_datetime64_any_dtype(raw_df["Date Op"])
     assert pd.api.types.is_numeric_dtype(raw_df["Total recette realise"])
     assert datasets["phase1"].shape[0] == 2
+
+
+def test_load_datasets_structure(sample_files):
+    mod = importlib.import_module("phase4v3")
+    datasets = mod.load_datasets(sample_files)
+
+    expected_cols = ["Date Op", "Total recette realise", "Categorie"]
+    expected_rows = {"raw": 2, "phase1": 2, "phase2": 1, "phase3": 2}
+    for key, rows in expected_rows.items():
+        assert key in datasets
+        df = datasets[key]
+        assert isinstance(df, pd.DataFrame)
+        assert list(df.columns) == expected_cols
+        assert df.shape[0] == rows
+
+
+def test_load_datasets_with_dictionary(sample_files_with_dict):
+    mod = importlib.import_module("phase4v3")
+    datasets = mod.load_datasets(sample_files_with_dict)
+
+    expected = ["date", "recette", "categorie"]
+    for df in datasets.values():
+        assert list(df.columns) == expected
+
+
+def test_load_datasets_global_config(sample_files):
+    mod = importlib.import_module("phase4v3")
+    mod.CONFIG.clear()
+    mod.CONFIG.update(sample_files)
+    datasets = mod.load_datasets()
+    assert "raw" in datasets and isinstance(datasets["raw"], pd.DataFrame)
 
 
 def test_run_pipeline(tmp_path: Path, sample_files):


### PR DESCRIPTION
## Summary
- define `CONFIG` global variable for default configuration
- allow `load_datasets()` to use global config and apply column mapping to the raw dataset
- expand unit tests to check column mapping and global config usage

## Testing
- `pytest -q`
