### PR TITLE
Implement dataset version comparison and speed up non-linear imports

### DIFF
--- a/test_nonlinear_methods.py
+++ b/test_nonlinear_methods.py
@@ -65,4 +65,7 @@ def test_run_pacmap_basic():
 def test_run_all_nonlinear():
     df = sample_df()
     results = run_all_nonlinear(df)
-    assert set(results.keys()) >= {"umap", "phate", "pacmap"}
+    assert "umap" in results and "phate" in results
+    # PaCMAP may be skipped if the library is unavailable
+    if "pacmap" in results:
+        assert isinstance(results["pacmap"], dict)


### PR DESCRIPTION
## Summary
- implement dataset comparison pipeline in `dataset_comparison.py`
- lazily import heavy non-linear libraries in `nonlinear_methods.py`
- avoid running PaCMAP when package is unavailable
- update tests for new behaviour

## Testing
- `pytest -q`