### PR TITLE
Remove obsolete config variable

### DIFF
--- a/phase4v3.py
+++ b/phase4v3.py
@@ -1486,7 +1486,6 @@ def main(argv: Optional[List[str]] = None) -> None:
     np.random.seed(0)
     random.seed(0)
     cfg = _load_config(Path(args.config))
-    CONFIG.update(cfg)
     run_pipeline(cfg)
 
 


### PR DESCRIPTION
## Summary
- fix leftover call to undefined CONFIG variable in `main`

## Testing
- `pytest -q`