### PR TITLE
Add global config and mapping tests

### DIFF
--- a/phase4v3.py
+++ b/phase4v3.py
@@ -55,6 +55,11 @@ except Exception:  # pragma: no cover - optional dependency may not be present
 
 from best_params import BEST_PARAMS
 
+# Global configuration used when ``load_datasets`` or other functions are
+# called without an explicit ``config`` parameter.  Tests may override this
+# dictionary by updating its values.
+CONFIG: Dict[str, Any] = {}
+
 
 # ---------------------------------------------------------------------------
 # Data Loading & Preparation
@@ -99,27 +104,30 @@ def _load_data_dictionary(path: Optional[Path]) -> Dict[str, str]:
     return mapping
 
 
-def load_datasets(config: Dict[str, Any]) -> Dict[str, pd.DataFrame]:
-    """Load raw and cleaned datasets specified in ``config``."""
+def load_datasets(config: Optional[Mapping[str, Any]] = None) -> Dict[str, pd.DataFrame]:
+    """Load raw and cleaned datasets specified in ``config`` or ``CONFIG``."""
     logger = logging.getLogger(__name__)
-    if "input_file" not in config:
+    cfg = CONFIG if config is None else config
+    if not isinstance(cfg, Mapping):
+        raise TypeError("config must be a mapping")
+    if "input_file" not in cfg:
         raise ValueError("'input_file' missing from config")
     datasets: Dict[str, pd.DataFrame] = {}
-    raw_path = Path(config["input_file"])
-    datasets["raw"] = _read_dataset(raw_path)
+    mapping = _load_data_dictionary(Path(cfg.get("data_dictionary", "")))
+
+    def _apply_mapping(df: pd.DataFrame) -> pd.DataFrame:
+        if mapping:
+            df = df.rename(columns={c: mapping.get(c, c) for c in df.columns})
+        return df
+
+    raw_path = Path(cfg["input_file"])
+    datasets["raw"] = _apply_mapping(_read_dataset(raw_path))
     logger.info(
         "Raw dataset loaded from %s [%d rows, %d cols]",
         raw_path,
         datasets["raw"].shape[0],
         datasets["raw"].shape[1],
     )
-
-    mapping = _load_data_dictionary(Path(config.get("data_dictionary", "")))
-
-    def _apply_mapping(df: pd.DataFrame) -> pd.DataFrame:
-        if mapping:
-            df = df.rename(columns={c: mapping.get(c, c) for c in df.columns})
-        return df
 
     for key, cfg_key in [
         ("phase1", "phase1_file"),
@@ -128,7 +136,7 @@ def load_datasets(config: Dict[str, Any]) -> Dict[str, pd.DataFrame]:
         ("phase3_multi", "phase3_multi_file"),
         ("phase3_univ", "phase3_univ_file"),
     ]:
-        path_str = config.get(cfg_key)
+        path_str = cfg.get(cfg_key)
         if not path_str:
             continue
         path = Path(path_str)

--- a/test_phase4v3.py
+++ b/test_phase4v3.py
@@ -35,6 +35,43 @@ def sample_files(tmp_path: Path):
     }
 
 
+@pytest.fixture()
+def sample_files_with_dict(tmp_path: Path):
+    raw = pd.DataFrame(
+        {
+            "Date Op": ["2024-01-01"],
+            "Total recette realise": ["1 000"],
+            "Categorie": ["A"],
+        }
+    )
+    raw_path = tmp_path / "raw.csv"
+    raw.to_csv(raw_path, index=False)
+
+    phase1_path = tmp_path / "phase1.csv"
+    raw.to_csv(phase1_path, index=False)
+    phase2_path = tmp_path / "phase2.csv"
+    raw.iloc[:0].to_csv(phase2_path, index=False)
+    phase3_path = tmp_path / "phase3.csv"
+    raw.to_csv(phase3_path, index=False)
+
+    mapping = pd.DataFrame(
+        {
+            "original": ["Date Op", "Total recette realise", "Categorie"],
+            "renamed": ["Date", "Recette", "Cat"],
+        }
+    )
+    dict_path = tmp_path / "dict.xlsx"
+    mapping.to_excel(dict_path, index=False)
+
+    return {
+        "input_file": str(raw_path),
+        "phase1_file": str(phase1_path),
+        "phase2_file": str(phase2_path),
+        "phase3_file": str(phase3_path),
+        "data_dictionary": str(dict_path),
+    }
+
+
 def test_load_datasets_types(sample_files):
     mod = importlib.import_module("phase4v3")
     datasets = mod.load_datasets(sample_files)
@@ -44,6 +81,20 @@ def test_load_datasets_types(sample_files):
     assert pd.api.types.is_datetime64_any_dtype(raw_df["Date Op"])
     assert pd.api.types.is_numeric_dtype(raw_df["Total recette realise"])
     assert datasets["phase1"].shape[0] == 2
+
+
+def test_load_datasets_structure(sample_files):
+    mod = importlib.import_module("phase4v3")
+    datasets = mod.load_datasets(sample_files)
+
+    expected_cols = ["Date Op", "Total recette realise", "Categorie"]
+    expected_rows = {"raw": 2, "phase1": 2, "phase2": 1, "phase3": 2}
+    for key, rows in expected_rows.items():
+        assert key in datasets
+        df = datasets[key]
+        assert isinstance(df, pd.DataFrame)
+        assert list(df.columns) == expected_cols
+        assert df.shape[0] == rows
 
 
 def test_run_pipeline(tmp_path: Path, sample_files):
@@ -56,3 +107,20 @@ def test_run_pipeline(tmp_path: Path, sample_files):
     assert "metrics" in out
     assert isinstance(out["metrics"], pd.DataFrame)
     assert (tmp_path / "metrics.csv").exists()
+
+
+def test_load_datasets_mapping(sample_files_with_dict):
+    mod = importlib.import_module("phase4v3")
+    datasets = mod.load_datasets(sample_files_with_dict)
+
+    for df in datasets.values():
+        assert list(df.columns) == ["Date", "Recette", "Cat"]
+
+
+def test_load_datasets_global_config(sample_files):
+    mod = importlib.import_module("phase4v3")
+    mod.CONFIG.clear()
+    mod.CONFIG.update(sample_files)
+
+    datasets = mod.load_datasets()
+    assert set(datasets) >= {"raw", "phase1", "phase2", "phase3"}


### PR DESCRIPTION
## Summary
- add a global CONFIG dictionary
- apply column renaming to the raw dataset
- allow calling `load_datasets()` without arguments using CONFIG
- extend unit tests to cover column mapping and default config behavior

## Testing
- `pytest -q`