### PR TITLE
Add keep_lost test and fix whitespace

### DIFF
--- a/test_prepare_data.py
+++ b/test_prepare_data.py
@@ -64,3 +64,45 @@ def test_prepare_data_flag_file(tmp_path: Path):
     cleaned = mod.prepare_data(df, exclude_lost=False, flagged_ids_path=flagged_path)
 
     assert list(cleaned["Code"]) == [1, 3]
+
+def test_prepare_data_imputes_missing_values():
+    mod = importlib.import_module("data_preparation")
+
+    df = pd.DataFrame(
+        {
+            "Code": [1, 2, 3],
+            "Date de début actualisée": ["2024-01-01"] * 3,
+            "Date de fin réelle": ["2024-01-02"] * 3,
+            "Total recette réalisé": [np.nan, "-5", "100"],
+            "Budget client estimé": [np.nan, 40, 60],
+            "Statut commercial": ["Gagné", "Gagné", "Gagné"],
+        }
+    )
+
+    cleaned = mod.prepare_data(df, exclude_lost=False)
+
+    num_cols = cleaned.select_dtypes(include=np.number).columns
+    assert not cleaned[num_cols].isna().any().any()
+
+    means = cleaned[num_cols.difference(["Code"])].mean()
+    assert np.allclose(means, 0, atol=1e-6)
+
+
+def test_prepare_data_keep_lost():
+    mod = importlib.import_module("data_preparation")
+
+    df = pd.DataFrame(
+        {
+            "Code": [1, 2, 3],
+            "Date de début actualisée": ["2024-01-01"] * 3,
+            "Date de fin réelle": ["2024-01-02"] * 3,
+            "Total recette réalisé": [10, 20, 30],
+            "Budget client estimé": [10, 20, 30],
+            "Statut commercial": ["Gagné", "Perdu", "Annulé"],
+        }
+    )
+
+    cleaned = mod.prepare_data(df, exclude_lost=False)
+
+    assert list(cleaned["Code"]) == [1, 2, 3]
+


### PR DESCRIPTION
## Summary
- verify numeric NaNs are imputed in `prepare_data`
- ensure lost opportunities remain when `exclude_lost=False`
- tidy whitespace in new test

## Testing
- `pytest -q`