### PR TITLE
Add cluster label reuse

### DIFF
--- a/evaluate_methods.py
+++ b/evaluate_methods.py
@@ -127,7 +127,9 @@ def evaluate_methods(
         cum_inertia = float(sum(inertias) * 100) if inertias else np.nan
 
         X_low = info["embeddings"].values
-        labels = KMeans(n_clusters=n_clusters, random_state=None).fit_predict(X_low)
+        kmeans = KMeans(n_clusters=n_clusters, random_state=None)
+        labels = kmeans.fit_predict(X_low)
+        info["cluster_labels"] = labels
         if len(labels) <= n_clusters or len(set(labels)) < 2:
             sil = float("nan")
             dunn = float("nan")

--- a/test_evaluate_methods.py
+++ b/test_evaluate_methods.py
@@ -46,6 +46,10 @@ def test_evaluate_and_plot(tmp_path, monkeypatch):
 
     metrics = em.evaluate_methods(results, df, quant_vars, qual_vars, n_clusters=2)
 
+    for method, info in results.items():
+        assert "cluster_labels" in info
+        assert len(info["cluster_labels"]) == len(df)
+
     assert set(metrics.columns) == {
         "variance_cumulee_%",
         "nb_axes_kaiser",

--- a/test_plot_cluster_scatter.py
+++ b/test_plot_cluster_scatter.py
@@ -1,0 +1,13 @@
+import pandas as pd
+import numpy as np
+import matplotlib
+matplotlib.use("Agg")
+from visualization import plot_cluster_scatter
+
+
+def test_plot_cluster_scatter_basic():
+    emb = pd.DataFrame({"x": [0, 1, 0, 1], "y": [0, 0, 1, 1]})
+    labels = np.array([0, 0, 1, 1])
+    fig = plot_cluster_scatter(emb, labels, "test")
+    assert hasattr(fig, "savefig")
+

--- a/visualization.py
+++ b/visualization.py
@@ -7,7 +7,6 @@ matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 from pathlib import Path
 from mpl_toolkits.mplot3d import Axes3D  # noqa: F401
-from pathlib import Path
 import pandas as pd
 import seaborn as sns
 import numpy as np
@@ -292,9 +291,14 @@ def generate_figures(
             fig = plot_scatter_2d(emb.iloc[:, :2], df_active, color_var, title)
             figures[f"{method}_scatter_2d"] = fig
             _save(fig, method, f"{method}_scatter_2d")
-            km = KMeans(n_clusters=cluster_k, random_state=0)
-            labels = km.fit_predict(emb.iloc[:, :2].values)
-            title = f"Projection {method.upper()} – coloration par clusters (k={cluster_k})"
+            if "cluster_labels" in res:
+                labels = np.asarray(res["cluster_labels"])
+                k_used = len(np.unique(labels))
+            else:
+                km = KMeans(n_clusters=cluster_k, random_state=0)
+                labels = km.fit_predict(emb.iloc[:, :2].values)
+                k_used = cluster_k
+            title = f"Projection {method.upper()} – coloration par clusters (k={k_used})"
             cfig = plot_cluster_scatter(emb.iloc[:, :2], labels, title)
             figures[f"{method}_clusters"] = cfig
             _save(cfig, method, f"{method}_clusters")
@@ -339,9 +343,14 @@ def generate_figures(
             fig = plot_scatter_2d(emb.iloc[:, :2], df_active, color_var, title)
             figures[f"{method}_scatter_2d"] = fig
             _save(fig, method, f"{method}_scatter_2d")
-            km = KMeans(n_clusters=cluster_k, random_state=0)
-            labels = km.fit_predict(emb.iloc[:, :2].values)
-            title = f"Projection {method.upper()} – coloration par clusters (k={cluster_k})"
+            if "cluster_labels" in res:
+                labels = np.asarray(res["cluster_labels"])
+                k_used = len(np.unique(labels))
+            else:
+                km = KMeans(n_clusters=cluster_k, random_state=0)
+                labels = km.fit_predict(emb.iloc[:, :2].values)
+                k_used = cluster_k
+            title = f"Projection {method.upper()} – coloration par clusters (k={k_used})"
             cfig = plot_cluster_scatter(emb.iloc[:, :2], labels, title)
             figures[f"{method}_clusters"] = cfig
             _save(cfig, method, f"{method}_clusters")


### PR DESCRIPTION
## Summary
- store clustering labels in `evaluate_methods`
- reuse provided labels in `generate_figures` to avoid recomputation
- check returned labels in unit tests

## Testing
- `pytest -q`