### PR TITLE
Enhance figure generation utilities

### DIFF
--- a/test_generate_figures.py
+++ b/test_generate_figures.py
@@ -89,8 +89,8 @@ def test_generate_figures_missing_f2(tmp_path):
     )
     # scatter plot should still be produced
     assert "pca_scatter_2d" in figs
-    # correlation plot cannot be generated with a single axis
-    assert "pca_correlation" not in figs
+    # correlation plot can be computed from embeddings
+    assert "pca_correlation" in figs
 
 
 def test_generate_figures_clusters(tmp_path):

--- a/visualization.py
+++ b/visualization.py
@@ -7,7 +7,6 @@ matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 from pathlib import Path
 from mpl_toolkits.mplot3d import Axes3D  # noqa: F401
-from pathlib import Path
 import pandas as pd
 import seaborn as sns
 import numpy as np
@@ -181,6 +180,24 @@ def _extract_quant_coords(coords: pd.DataFrame, quant_vars: List[str]) -> pd.Dat
     subset = subset.rename(columns={cols[0]: "F1", cols[1]: "F2"})
     return subset
 
+
+def _corr_from_embeddings(
+    emb: pd.DataFrame, df_active: pd.DataFrame, quant_vars: List[str]
+) -> pd.DataFrame:
+    """Return correlations of quantitative variables with the first two dims."""
+    if emb.shape[1] < 2:
+        return pd.DataFrame(columns=["F1", "F2"])
+    data = {}
+    f1 = emb.iloc[:, 0]
+    f2 = emb.iloc[:, 1]
+    for var in quant_vars:
+        if var in df_active.columns:
+            series = df_active.loc[emb.index, var]
+            data[var] = [series.corr(f1), series.corr(f2)]
+    if not data:
+        return pd.DataFrame(columns=["F1", "F2"])
+    return pd.DataFrame(data, index=["F1", "F2"]).T
+
 def plot_scree(inertia: pd.Series, title: str) -> plt.Figure:
     """Return a scree plot showing variance explained by each component."""
     axes = range(1, len(inertia) + 1)
@@ -218,42 +235,6 @@ def plot_famd_contributions(contrib: pd.DataFrame, n: int = 10) -> plt.Figure:
 
 
 
-def plot_scree(inertia: pd.Series, title: str) -> plt.Figure:
-    """Return a scree plot showing variance explained by each component."""
-    axes = range(1, len(inertia) + 1)
-    fig, ax = plt.subplots(figsize=(12, 6), dpi=200)
-    ax.bar(axes, inertia.values * 100, edgecolor="black")
-    ax.plot(axes, np.cumsum(inertia.values) * 100, "-o", color="orange")
-    ax.set_xlabel("Composante")
-    ax.set_ylabel("% Variance expliquée")
-    ax.set_title(title)
-    ax.set_xticks(list(axes))
-    fig.tight_layout()
-    return fig
-
-
-def plot_famd_contributions(contrib: pd.DataFrame, n: int = 10) -> plt.Figure:
-    """Return a bar plot of variable contributions to F1 and F2."""
-    if not {"F1", "F2"}.issubset(contrib.columns):
-        cols = contrib.columns[:2]
-        contrib = contrib.rename(columns={cols[0]: "F1", cols[1]: "F2"})
-    grouped: Dict[str, pd.Series] = {}
-    for idx in contrib.index:
-        var = idx.split("__", 1)[0]
-        grouped.setdefault(var, pd.Series(dtype=float))
-        grouped[var] = grouped[var].add(contrib.loc[idx, ["F1", "F2"]], fill_value=0)
-    df = pd.DataFrame(grouped).T.fillna(0)
-    df = df.sort_values(df.sum(axis=1).name if df.columns.size > 2 else 0, ascending=False)
-    df = df.iloc[:n]
-    fig, ax = plt.subplots(figsize=(12, 6), dpi=200)
-    df[["F1", "F2"]].plot(kind="bar", stacked=True, ax=ax)
-    ax.set_ylabel("% Contribution")
-    ax.set_title("Contribution des variables à F1/F2 – FAMD")
-    ax.legend(title="Axe")
-    fig.tight_layout()
-    return fig
-
-
 def generate_figures(
     factor_results: Dict[str, Dict[str, Any]],
     nonlin_results: Dict[str, Dict[str, Any]],
@@ -275,7 +256,8 @@ def generate_figures(
     """
     color_var = _choose_color_var(df_active, qual_vars)
     figures: Dict[str, plt.Figure] = {}
-    first_3d_done = False
+    first_3d_factor = False
+    first_3d_nonlin = False
     out = Path(output_dir) if output_dir is not None else None
 
     def _save(fig: plt.Figure, method: str, name: str) -> None:
@@ -284,6 +266,7 @@ def generate_figures(
         sub = out / method.lower()
         sub.mkdir(parents=True, exist_ok=True)
         fig.savefig(sub / f"{name}.png")
+        plt.close(fig)
 
     for method, res in factor_results.items():
         emb = res.get("embeddings")
@@ -298,7 +281,7 @@ def generate_figures(
             cfig = plot_cluster_scatter(emb.iloc[:, :2], labels, title)
             figures[f"{method}_clusters"] = cfig
             _save(cfig, method, f"{method}_clusters")
-            if not first_3d_done and emb.shape[1] >= 3:
+            if not first_3d_factor and emb.shape[1] >= 3:
                 fig3d = plot_scatter_3d(
                     emb.iloc[:, :3],
                     df_active,
@@ -307,19 +290,25 @@ def generate_figures(
                 )
                 figures[f"{method}_scatter_3d"] = fig3d
                 _save(fig3d, method, f"{method}_scatter_3d")
-                first_3d_done = True
+                first_3d_factor = True
         coords = res.get("loadings")
         if coords is None:
             coords = res.get("column_coords")
         if isinstance(coords, pd.DataFrame):
             qcoords = _extract_quant_coords(coords, quant_vars)
-            if not qcoords.empty:
-                var_pc = res.get("inertia")
-                pct = float(var_pc.iloc[:2].sum() * 100) if isinstance(var_pc, pd.Series) else float("nan")
-                title = f"{method.upper()} – cercle des corrélations (F1–F2)\nVariance {pct:.1f}%"
-                fig_corr = plot_correlation_circle(qcoords, title)
-                figures[f"{method}_correlation"] = fig_corr
-                _save(fig_corr, method, f"{method}_correlation")
+            if qcoords.empty and isinstance(emb, pd.DataFrame):
+                qcoords = _corr_from_embeddings(emb, df_active, quant_vars)
+        elif isinstance(emb, pd.DataFrame):
+            qcoords = _corr_from_embeddings(emb, df_active, quant_vars)
+        else:
+            qcoords = pd.DataFrame()
+        if not qcoords.empty:
+            var_pc = res.get("inertia")
+            pct = float(var_pc.iloc[:2].sum() * 100) if isinstance(var_pc, pd.Series) else float("nan")
+            title = f"{method.upper()} – cercle des corrélations (F1–F2)\nVariance {pct:.1f}%"
+            fig_corr = plot_correlation_circle(qcoords, title)
+            figures[f"{method}_correlation"] = fig_corr
+            _save(fig_corr, method, f"{method}_correlation")
         inertia = res.get("inertia")
         if isinstance(inertia, pd.Series) and not inertia.empty:
             fig_scree = plot_scree(inertia, f"Variance expliquée par composante – {method.upper()}")
@@ -345,7 +334,7 @@ def generate_figures(
             cfig = plot_cluster_scatter(emb.iloc[:, :2], labels, title)
             figures[f"{method}_clusters"] = cfig
             _save(cfig, method, f"{method}_clusters")
-            if not first_3d_done and emb.shape[1] >= 3:
+            if not first_3d_nonlin and emb.shape[1] >= 3:
                 fig3d = plot_scatter_3d(
                     emb.iloc[:, :3],
                     df_active,
@@ -354,6 +343,6 @@ def generate_figures(
                 )
                 figures[f"{method}_scatter_3d"] = fig3d
                 _save(fig3d, method, f"{method}_scatter_3d")
-                first_3d_done = True
+                first_3d_nonlin = True
 
     return figures


### PR DESCRIPTION
## Summary
- deduplicate visualization utilities and extend them
- compute correlation circle coordinates from embeddings when loadings miss F2
- generate a 3D scatter for one linear and one non-linear method
- update tests for new behaviour
- close figures after saving and cleanup duplicate imports

## Testing
- `pytest test_generate_figures.py::test_generate_figures_missing_f2 -q`
- `pytest -q`