### PR TITLE
Add cluster label reuse in figures

### DIFF
--- a/evaluate_methods.py
+++ b/evaluate_methods.py
@@ -128,6 +128,7 @@ def evaluate_methods(
 
         X_low = info["embeddings"].values
         labels = KMeans(n_clusters=n_clusters, random_state=None).fit_predict(X_low)
+        info["cluster_labels"] = labels
         if len(labels) <= n_clusters or len(set(labels)) < 2:
             sil = float("nan")
             dunn = float("nan")

--- a/test_evaluate_methods.py
+++ b/test_evaluate_methods.py
@@ -45,6 +45,10 @@ def test_evaluate_and_plot(tmp_path, monkeypatch):
     monkeypatch.setattr(em, "trustworthiness", lambda *args, **kwargs: 0.5)
 
     metrics = em.evaluate_methods(results, df, quant_vars, qual_vars, n_clusters=2)
+    assert "cluster_labels" in results["A"]
+    assert len(results["A"]["cluster_labels"]) == len(df)
+    assert "cluster_labels" in results["B"]
+    assert len(results["B"]["cluster_labels"]) == len(df)
 
     assert set(metrics.columns) == {
         "variance_cumulee_%",

--- a/test_generate_figures.py
+++ b/test_generate_figures.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import numpy as np
 import matplotlib
 matplotlib.use("Agg")
 
@@ -93,22 +94,33 @@ def test_generate_figures_missing_f2(tmp_path):
     assert "pca_correlation" not in figs
 
 
-def test_generate_figures_clusters(tmp_path):
+def test_generate_figures_clusters(tmp_path, monkeypatch):
     df = pd.DataFrame({
         "num1": [1, 2, 3, 4],
         "num2": [4, 3, 2, 1],
         "cat": ["a", "b", "a", "b"],
     })
 
+    labels = np.array([0, 0, 1, 1])
     factor_results = {
         "pca": {
             "embeddings": pd.DataFrame(
                 [[0.1, 0.2], [0.0, -0.1], [0.2, 0.1], [-0.2, -0.1]],
                 index=df.index,
                 columns=["F1", "F2"],
-            )
+            ),
+            "cluster_labels": labels,
         }
     }
+
+    class DummyKM:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def fit_predict(self, *args, **kwargs):
+            raise AssertionError("KMeans should not be called")
+
+    monkeypatch.setattr("visualization.KMeans", DummyKM)
 
     figs = generate_figures(
         factor_results,

--- a/test_plot_cluster_scatter.py
+++ b/test_plot_cluster_scatter.py
@@ -1,0 +1,13 @@
+import pandas as pd
+import numpy as np
+import matplotlib
+matplotlib.use("Agg")
+from visualization import plot_cluster_scatter
+
+
+def test_plot_cluster_scatter_basic():
+    emb = pd.DataFrame({"x": [0, 1, 0, 1], "y": [0, 0, 1, 1]})
+    labels = np.array([0, 0, 1, 1])
+    fig = plot_cluster_scatter(emb, labels, "test")
+    assert hasattr(fig, "savefig")
+

--- a/visualization.py
+++ b/visualization.py
@@ -292,9 +292,14 @@ def generate_figures(
             fig = plot_scatter_2d(emb.iloc[:, :2], df_active, color_var, title)
             figures[f"{method}_scatter_2d"] = fig
             _save(fig, method, f"{method}_scatter_2d")
-            km = KMeans(n_clusters=cluster_k, random_state=0)
-            labels = km.fit_predict(emb.iloc[:, :2].values)
-            title = f"Projection {method.upper()} – coloration par clusters (k={cluster_k})"
+            labels = res.get("cluster_labels")
+            if labels is None or len(labels) != len(emb):
+                km = KMeans(n_clusters=cluster_k, random_state=0)
+                labels = km.fit_predict(emb.iloc[:, :2].values)
+            k_used = len(np.unique(labels))
+            title = (
+                f"Projection {method.upper()} – coloration par clusters (k={k_used})"
+            )
             cfig = plot_cluster_scatter(emb.iloc[:, :2], labels, title)
             figures[f"{method}_clusters"] = cfig
             _save(cfig, method, f"{method}_clusters")
@@ -339,9 +344,14 @@ def generate_figures(
             fig = plot_scatter_2d(emb.iloc[:, :2], df_active, color_var, title)
             figures[f"{method}_scatter_2d"] = fig
             _save(fig, method, f"{method}_scatter_2d")
-            km = KMeans(n_clusters=cluster_k, random_state=0)
-            labels = km.fit_predict(emb.iloc[:, :2].values)
-            title = f"Projection {method.upper()} – coloration par clusters (k={cluster_k})"
+            labels = res.get("cluster_labels")
+            if labels is None or len(labels) != len(emb):
+                km = KMeans(n_clusters=cluster_k, random_state=0)
+                labels = km.fit_predict(emb.iloc[:, :2].values)
+            k_used = len(np.unique(labels))
+            title = (
+                f"Projection {method.upper()} – coloration par clusters (k={k_used})"
+            )
             cfig = plot_cluster_scatter(emb.iloc[:, :2], labels, title)
             figures[f"{method}_clusters"] = cfig
             _save(cfig, method, f"{method}_clusters")


### PR DESCRIPTION
## Summary
- store `cluster_labels` in `evaluate_methods`
- adapt `generate_figures` to reuse stored labels and show actual k
- extend tests for evaluate_methods and generate_figures
- add basic plotting test for `plot_cluster_scatter`

## Testing
- `pytest -q`