### PR TITLE
Add weighting arg to FAMD

### DIFF
--- a/factor_methods.py
+++ b/factor_methods.py
@@ -228,10 +228,14 @@ def run_famd(
     optimize: bool = False,
     variance_threshold: float = 0.8,
     random_state: Optional[int] = 0,
+    weighting: Optional[str] = None,
 ) -> Dict[str, object]:
     """Run Factor Analysis of Mixed Data (FAMD)."""
     start = time.perf_counter()
     logger = logging.getLogger(__name__)
+
+    if weighting is not None:
+        logger.info("FAMD weighting=%s ignored (not implemented)", weighting)
 
     scaler = StandardScaler()
     X_quanti = scaler.fit_transform(df_active[quant_vars])

--- a/phase4v3.py
+++ b/phase4v3.py
@@ -475,10 +475,14 @@ def run_famd(
     optimize: bool = False,
     variance_threshold: float = 0.8,
     random_state: Optional[int] = None,
+    weighting: Optional[str] = None,
 ) -> Dict[str, object]:
     """Run Factor Analysis of Mixed Data (FAMD)."""
     start = time.perf_counter()
     logger = logging.getLogger(__name__)
+
+    if weighting is not None:
+        logger.info("FAMD weighting=%s ignored (not implemented)", weighting)
 
     scaler = StandardScaler()
     X_quanti = scaler.fit_transform(df_active[quant_vars])


### PR DESCRIPTION
## Summary
- accept an optional `weighting` parameter in `run_famd`
- ignore the argument for now but avoid TypeError when config includes it

## Testing
- `pytest -q`