### PR TITLE
Add weighting arg to FAMD

### DIFF
--- a/factor_methods.py
+++ b/factor_methods.py
@@ -228,10 +228,27 @@ def run_famd(
     optimize: bool = False,
     variance_threshold: float = 0.8,
     random_state: Optional[int] = 0,
+    weighting: Optional[str] = None,
+    n_components_rule: Optional[str] = None,
 ) -> Dict[str, object]:
-    """Run Factor Analysis of Mixed Data (FAMD)."""
+    """Run Factor Analysis of Mixed Data (FAMD).
+
+    Parameters
+    ----------
+    n_components_rule : str, optional
+        Placeholder for compatibility with configuration files. Currently
+        ignored.
+    """
     start = time.perf_counter()
     logger = logging.getLogger(__name__)
+
+    if weighting is not None:
+        logger.info("FAMD weighting=%s ignored (not implemented)", weighting)
+    if n_components_rule is not None:
+        logger.info(
+            "FAMD n_components_rule=%s ignored (not implemented)",
+            n_components_rule,
+        )
 
     scaler = StandardScaler()
     X_quanti = scaler.fit_transform(df_active[quant_vars])

--- a/phase4v3.py
+++ b/phase4v3.py
@@ -475,10 +475,27 @@ def run_famd(
     optimize: bool = False,
     variance_threshold: float = 0.8,
     random_state: Optional[int] = None,
+    weighting: Optional[str] = None,
+    n_components_rule: Optional[str] = None,
 ) -> Dict[str, object]:
-    """Run Factor Analysis of Mixed Data (FAMD)."""
+    """Run Factor Analysis of Mixed Data (FAMD).
+
+    Parameters
+    ----------
+    n_components_rule : str, optional
+        Placeholder for compatibility with configuration files. Currently
+        ignored.
+    """
     start = time.perf_counter()
     logger = logging.getLogger(__name__)
+
+    if weighting is not None:
+        logger.info("FAMD weighting=%s ignored (not implemented)", weighting)
+    if n_components_rule is not None:
+        logger.info(
+            "FAMD n_components_rule=%s ignored (not implemented)",
+            n_components_rule,
+        )
 
     scaler = StandardScaler()
     X_quanti = scaler.fit_transform(df_active[quant_vars])

--- a/test_factor_methods.py
+++ b/test_factor_methods.py
@@ -101,3 +101,16 @@ def test_run_mfa_groups():
     res = run_mfa(df, groups, optimize=True)
     assert set(["runtime", "coords"]).issubset(res.keys())
     assert res["embeddings"].shape[0] == len(df)
+
+
+def test_run_famd_extra_kwargs():
+    df = sample_df()
+    res = run_famd(
+        df,
+        ["num1", "num2"],
+        ["cat1", "cat2"],
+        optimize=True,
+        weighting="balanced",
+        n_components_rule="elbow",
+    )
+    assert res["embeddings"].shape[0] == len(df)


### PR DESCRIPTION
## Summary
- accept an optional `weighting` parameter in `run_famd`
- ignore the argument for now but avoid TypeError when config includes it

## Testing
- `pytest -q`
