### PR TITLE
Implement MFA weights

### DIFF
--- a/phase4_functions.py
+++ b/phase4_functions.py
@@ -698,7 +698,7 @@ independently of ``phase4v2.py`` or the fine-tuning scripts.
 
 import logging
 import time
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Sequence, Mapping, Union
 
 from pandas.api.types import is_object_dtype, is_categorical_dtype
 
@@ -987,12 +987,13 @@ def run_famd(
 
 def run_mfa(
     df_active: pd.DataFrame,
-    groups: List[List[str]],
+    groups: Union[Mapping[str, Sequence[str]], Sequence[Sequence[str]]],
     n_components: Optional[int] = None,
     *,
     optimize: bool = False,
     variance_threshold: float = 0.8,
     normalize: bool = True,
+    weights: Optional[Union[Mapping[str, float], Sequence[float]]] = None,
     n_iter: int = 3,
 ) -> Dict[str, object]:
     """Run Multiple Factor Analysis.
@@ -1001,13 +1002,22 @@ def run_mfa(
     element of ``groups`` must be a list of column names present in
     ``df_active``. When invoking :func:`run_pipeline`, these groups can be
     provided in the configuration file under ``mfa: {groups: ...}``.
+    ``weights`` allows adjusting the relative importance of each group by
+    multiplying its (optionally normalised) columns by the specified factor.
     """
     start = time.perf_counter()
     logger = logging.getLogger(__name__)
 
+    if isinstance(groups, Mapping):
+        group_names = list(groups.keys())
+        group_list = list(groups.values())
+    else:
+        group_list = list(groups)
+        group_names = [f"G{i}" for i in range(1, len(group_list) + 1)]
+
     # one-hot encode qualitative variables that appear in groups
     qual_cols = []
-    for group in groups:
+    for group in group_list:
         for col in group:
             if col in df_active.columns and (
                 is_object_dtype(df_active[col]) or is_categorical_dtype(df_active[col])
@@ -1030,7 +1040,7 @@ def run_mfa(
 
     groups_dict: Dict[str, List[str]] = {}
     used_cols: List[str] = []
-    for i, g in enumerate(groups, 1):
+    for name, g in zip(group_names, group_list):
         cols: List[str] = []
         for v in g:
             if v in df_all.columns:
@@ -1039,7 +1049,6 @@ def run_mfa(
                 # qualitative variables have been expanded
                 cols.extend([c for c in df_all.columns if c.startswith(f"{v}_")])
         if cols:
-            name = f"G{i}"
             groups_dict[name] = cols
             used_cols.extend(cols)
 
@@ -1049,11 +1058,34 @@ def run_mfa(
         used_cols.extend(remaining)
     df_all = df_all[used_cols]
 
+    weights_map: Dict[str, float] = {}
+    if weights is not None:
+        if isinstance(weights, Mapping):
+            weights_map = {str(k): float(v) for k, v in weights.items()}
+        else:
+            weight_list = list(weights)
+            if len(weight_list) != len(group_names):
+                logger.warning(
+                    "MFA weights length mismatch: expected %d, got %d",
+                    len(group_names),
+                    len(weight_list),
+                )
+            for name, w in zip(group_names, weight_list):
+                weights_map[name] = float(w)
+
     if normalize:
         scaler = StandardScaler()
-        for cols in groups_dict.values():
+        for name, cols in groups_dict.items():
             if cols:
                 df_all[cols] = scaler.fit_transform(df_all[cols])
+            w = weights_map.get(name)
+            if w is not None and w != 1.0:
+                df_all[cols] = df_all[cols] * w
+    else:
+        for name, cols in groups_dict.items():
+            w = weights_map.get(name)
+            if w is not None and w != 1.0:
+                df_all[cols] = df_all[cols] * w
 
     if optimize and n_components is None:
         max_dim = df_all.shape[1]

--- a/tests/test_factor_methods.py
+++ b/tests/test_factor_methods.py
@@ -43,3 +43,10 @@ def test_run_mfa_basic():
     assert res["embeddings"].shape[0] == len(df)
     assert len(res["inertia"]) == res["embeddings"].shape[1]
 
+
+def test_run_mfa_with_weights():
+    df = sample_df()
+    groups = {"Num": ["num1", "num2"], "Cat": ["cat1", "cat2"]}
+    res = pf.run_mfa(df, groups, optimize=True, weights={"Num": 2.0, "Cat": 1.0})
+    assert res["embeddings"].shape[0] == len(df)
+


### PR DESCRIPTION
## Summary
- support group weighting in `run_mfa`
- accept mapping or sequence for MFA groups and weights
- test MFA weights

## Testing
- `pytest -q`