### PR TITLE
Fix None UMAP metric

### DIFF
--- a/phase4.py
+++ b/phase4.py
@@ -89,10 +89,12 @@ def _load_config(path: Path) -> Dict[str, Any]:
 def _method_params(method: str, config: Mapping[str, Any]) -> Dict[str, Any]:
     params = BEST_PARAMS.get(method.upper(), {}).copy()
     if method.lower() in config and isinstance(config[method.lower()], Mapping):
-        params.update(config[method.lower()])
+        for key, value in config[method.lower()].items():
+            if value is not None:
+                params[key] = value
     prefix = f"{method.lower()}_"
     for key, value in config.items():
-        if key.startswith(prefix):
+        if key.startswith(prefix) and value is not None:
             params[key[len(prefix) :]] = value
     return params
 

--- a/phase4_functions.py
+++ b/phase4_functions.py
@@ -1218,7 +1218,7 @@ def run_umap(
     n_neighbors: int = 15,
     min_dist: float = 0.1,
     *,
-    metric: str = "euclidean",
+    metric: str | None = "euclidean",
     n_jobs: int = -1,
 ) -> Dict[str, Any]:
     """Run UMAP on ``df_active`` and return model and embeddings.
@@ -1237,6 +1237,9 @@ def run_umap(
 
     start = time.perf_counter()
     X = _encode_mixed(df_active)
+
+    if metric is None:
+        metric = "euclidean"
 
     reducer = umap.UMAP(
         n_components=n_components,

--- a/tests/test_method_params.py
+++ b/tests/test_method_params.py
@@ -15,3 +15,13 @@ def test_method_params_merging():
     assert pacmap_params["MN_ratio"] == 0.7
     assert "n_neighbors" in pacmap_params  # default from BEST_PARAMS
 
+
+def test_method_params_ignore_none():
+    cfg = {
+        "umap": {"metric": None},
+        "umap_n_neighbors": None,
+    }
+    params = phase4._method_params("umap", cfg)
+    assert params["metric"] == "cosine"
+    assert params["n_neighbors"] == 30
+


### PR DESCRIPTION
## Summary
- ignore `None` values when merging method parameters
- default `metric` to euclidean when `None`
- add regression test for `_method_params` with `None` values

## Testing
- `pytest -q`
