### PR TITLE
Fix PHATE config alias

### DIFF
--- a/phase4_functions.py
+++ b/phase4_functions.py
@@ -1275,11 +1275,13 @@ def run_phate(
     a: int = 40,
     *,
     t: str | int = "auto",
+    knn: int | None = None,
 ) -> Dict[str, Any]:
     """Run PHATE on ``df_active``.
 
     The dataframe is encoded numerically via :func:`_encode_mixed` before
-    fitting PHATE.  Returns an empty result if the library is unavailable.
+    fitting PHATE.  The ``knn`` keyword is accepted as an alias for ``k``.
+    Returns an empty result if the library is unavailable.
     """
     global phate
     if phate is None:
@@ -1294,6 +1296,9 @@ def run_phate(
                 "embeddings": pd.DataFrame(index=df_active.index),
                 "params": {},
             }
+
+    if knn is not None:
+        k = knn
 
     start = time.perf_counter()
     X = _encode_mixed(df_active)

--- a/tests/test_nonlin_methods.py
+++ b/tests/test_nonlin_methods.py
@@ -36,6 +36,12 @@ def test_run_phate_basic():
         assert res["embeddings"].empty
 
 
+def test_run_phate_knn_alias():
+    df = sample_df()
+    res_knn = pf.run_phate(df, knn=3)
+    assert res_knn["params"]["k"] == 3
+
+
 def test_run_pacmap_basic():
     df = sample_df()
     res = pf.run_pacmap(df)


### PR DESCRIPTION
## Summary
- add `knn` keyword alias for PHATE
- test the new alias

## Testing
- `pytest -q`