### PR TITLE
Fix PHATE decay parameter handling

### DIFF
--- a/phase4_functions.py
+++ b/phase4_functions.py
@@ -1276,12 +1276,14 @@ def run_phate(
     *,
     t: str | int = "auto",
     knn: int | None = None,
+    decay: int | None = None,
 ) -> Dict[str, Any]:
     """Run PHATE on ``df_active``.
 
     The dataframe is encoded numerically via :func:`_encode_mixed` before
-    fitting PHATE.  The ``knn`` keyword is accepted as an alias for ``k``.
-    Returns an empty result if the library is unavailable.
+    fitting PHATE.  The ``knn`` keyword is accepted as an alias for ``k`` and
+    ``decay`` can be used as an alias for ``a``. Returns an empty result if the
+    library is unavailable.
     """
     global phate
     if phate is None:
@@ -1299,6 +1301,8 @@ def run_phate(
 
     if knn is not None:
         k = knn
+    if decay is not None:
+        a = decay
 
     start = time.perf_counter()
     X = _encode_mixed(df_active)

--- a/tests/test_nonlin_methods.py
+++ b/tests/test_nonlin_methods.py
@@ -42,6 +42,12 @@ def test_run_phate_knn_alias():
     assert res_knn["params"]["k"] == 3
 
 
+def test_run_phate_decay_alias():
+    df = sample_df()
+    res_decay = pf.run_phate(df, decay=5)
+    assert res_decay["params"]["a"] == 5
+
+
 def test_run_pacmap_basic():
     df = sample_df()
     res = pf.run_pacmap(df)


### PR DESCRIPTION
## Summary
- handle `decay` parameter when running PHATE
- test the new `decay` alias

## Testing
- `pytest -q`