### PR TITLE
Fix PHATE knn=auto error

### DIFF
--- a/phase4_functions.py
+++ b/phase4_functions.py
@@ -1300,7 +1300,13 @@ def run_phate(
             }
 
     if knn is not None:
-        k = knn
+        if isinstance(knn, str):
+            try:
+                k = int(knn)
+            except ValueError:  # invalid string like "auto"
+                logger.warning("Invalid PHATE knn value '%s'; using default", knn)
+        else:
+            k = knn
     if decay is not None:
         a = decay
 

--- a/tests/test_nonlin_methods.py
+++ b/tests/test_nonlin_methods.py
@@ -48,6 +48,13 @@ def test_run_phate_decay_alias():
     assert res_decay["params"]["a"] == 5
 
 
+def test_run_phate_knn_auto():
+    df = sample_df()
+    res = pf.run_phate(df, knn="auto")
+    # invalid string should fall back to default (15 from BEST_PARAMS)
+    assert res["params"]["k"] == 15
+
+
 def test_run_pacmap_basic():
     df = sample_df()
     res = pf.run_pacmap(df)


### PR DESCRIPTION
## Summary
- handle invalid string values for PHATE's `knn` parameter
- test that PHATE falls back to defaults when `knn="auto"`

## Testing
- `pytest -q`