### PR TITLE
Respect optimize_params in phase4

### DIFF
--- a/phase4.py
+++ b/phase4.py
@@ -254,6 +254,7 @@ def run_pipeline(config: Dict[str, Any]) -> Dict[str, Any]:
     _setup_logging(output_dir)
     n_jobs = int(config.get("n_jobs", -1))
     set_blas_threads(n_jobs)
+    optimize = bool(config.get("optimize_params", False))
 
     logging.info("Loading datasets...")
     datasets = load_datasets(config)
@@ -289,35 +290,38 @@ def run_pipeline(config: Dict[str, Any]) -> Dict[str, Any]:
     if "pca" in methods and quant_vars:
         logging.info("Running PCA...")
         params = _method_params("pca", config)
-        params.pop("n_components", None)
+        if optimize:
+            params.pop("n_components", None)
         factor_results["pca"] = run_pca(
             df_active,
             quant_vars,
-            optimize=True,
+            optimize=optimize,
             **params,
         )
 
     if "mca" in methods and qual_vars:
         logging.info("Running MCA...")
         params = _method_params("mca", config)
-        params.pop("n_components", None)
+        if optimize:
+            params.pop("n_components", None)
         factor_results["mca"] = run_mca(
             df_active,
             qual_vars,
-            optimize=True,
+            optimize=optimize,
             **params,
         )
 
     if "famd" in methods and quant_vars and qual_vars:
         logging.info("Running FAMD...")
         params = _method_params("famd", config)
-        params.pop("n_components", None)
+        if optimize:
+            params.pop("n_components", None)
         try:
             factor_results["famd"] = run_famd(
                 df_active,
                 quant_vars,
                 qual_vars,
-                optimize=True,
+                optimize=optimize,
                 **params,
             )
         except ValueError as exc:
@@ -331,7 +335,8 @@ def run_pipeline(config: Dict[str, Any]) -> Dict[str, Any]:
     if "mfa" in methods and len(groups) > 1:
         logging.info("Running MFA...")
         params = _method_params("mfa", config)
-        params.pop("n_components", None)
+        if optimize:
+            params.pop("n_components", None)
         cfg_groups = params.pop("groups", None)
         # ``mfa: {groups: [[...], [...]]}`` in the config overrides the default
         # automatic grouping of quantitative and qualitative variables.
@@ -340,7 +345,7 @@ def run_pipeline(config: Dict[str, Any]) -> Dict[str, Any]:
         factor_results["mfa"] = run_mfa(
             df_active,
             groups,
-            optimize=True,
+            optimize=optimize,
             **params,
         )
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,45 @@
+import pandas as pd
+import numpy as np
+import phase4
+from pathlib import Path
+
+
+def test_run_pipeline_respects_optimize(tmp_path, monkeypatch):
+    df = pd.DataFrame({
+        "num": [1, 2, 3, 4, 5, 6],
+        "cat": ["a", "b", "a", "b", "c", "a"],
+    })
+    csv_path = tmp_path / "raw.csv"
+    df.to_csv(csv_path, index=False)
+
+    cfg = {
+        "input_file": str(csv_path),
+        "dataset": "raw",
+        "output_dir": str(tmp_path / "out"),
+        "methods": ["famd"],
+        "optimize_params": False,
+        "min_modalite_freq": 1,
+        "famd": {"n_components": 2},
+    }
+
+    called = {}
+
+    def fake_run_famd(df_active, quant_vars, qual_vars, n_components=None, *, optimize=False, **kwargs):
+        called["n_components"] = n_components
+        called["optimize"] = optimize
+        cols = n_components or 1
+        emb = pd.DataFrame(
+            np.zeros((len(df_active), cols)),
+            index=df_active.index,
+            columns=[f"F{i+1}" for i in range(cols)],
+        )
+        return {"embeddings": emb}
+
+    monkeypatch.setattr(phase4, "run_famd", fake_run_famd)
+    monkeypatch.setattr(phase4, "evaluate_methods", lambda *a, **k: pd.DataFrame())
+    monkeypatch.setattr(phase4, "plot_methods_heatmap", lambda *a, **k: None)
+    monkeypatch.setattr(phase4, "generate_figures", lambda *a, **k: {})
+    phase4.run_pipeline(cfg)
+
+    assert called.get("optimize") is False
+    assert called.get("n_components") == 2

--- a/tests/test_threads.py
+++ b/tests/test_threads.py
@@ -4,12 +4,13 @@ from phase4 import set_blas_threads
 
 def test_set_blas_threads_sets_env(monkeypatch):
     for var in [
-        "OPENBLAS_NUM_THREADS",
-        "MKL_NUM_THREADS",
-        "OMP_NUM_THREADS",
+        'OPENBLAS_NUM_THREADS',
+        'MKL_NUM_THREADS',
+        'OMP_NUM_THREADS',
     ]:
         monkeypatch.delenv(var, raising=False)
     set_blas_threads(3)
-    assert os.environ["OPENBLAS_NUM_THREADS"] == "3"
-    assert os.environ["MKL_NUM_THREADS"] == "3"
-    assert os.environ["OMP_NUM_THREADS"] == "3"
+    assert os.environ['OPENBLAS_NUM_THREADS'] == '3'
+    assert os.environ['MKL_NUM_THREADS'] == '3'
+    assert os.environ['OMP_NUM_THREADS'] == '3'
+


### PR DESCRIPTION
## Summary
- update `run_pipeline` so each method honours `optimize_params`
- clean truncation artifact in `test_threads`
- add regression test ensuring `run_pipeline` uses `n_components` when optimization is disabled

## Testing
- `pytest -q`