### PR TITLE
Auto-tune clusters and remove segment colouring

### DIFF
--- a/phase4.py
+++ b/phase4.py
@@ -370,12 +370,13 @@ def run_pipeline(config: Dict[str, Any]) -> Dict[str, Any]:
         metrics = pd.DataFrame()
     else:
         logging.info("Computing metrics...")
+        k_max = 3 if len(df_active) > 3 else 2
         metrics = evaluate_methods(
             all_results,
             df_active,
             quant_vars,
             qual_vars,
-            n_clusters=3 if len(df_active) > 3 else 2,
+            k_range=range(2, k_max + 1),
         )
         metrics.to_csv(output_dir / "metrics.csv")
         plot_methods_heatmap(metrics, output_dir)

--- a/tests/test_evaluate_methods.py
+++ b/tests/test_evaluate_methods.py
@@ -36,7 +36,9 @@ def test_evaluate_and_plot(tmp_path, monkeypatch):
 
     monkeypatch.setattr(pf, "trustworthiness", lambda *args, **kwargs: 0.5)
 
-    metrics = pf.evaluate_methods(results, df, quant_vars, qual_vars, n_clusters=2)
+    metrics = pf.evaluate_methods(
+        results, df, quant_vars, qual_vars, k_range=range(2, 3)
+    )
 
     # cluster labels added
     for info in results.values():


### PR DESCRIPTION
## Summary
- automatically choose K-Means clusters via silhouette fine tuning
- remove business segment colouring from generated figures
- update phase 4 workflow to use tuned clusters
- adjust tests for new `evaluate_methods` API

## Testing
- `pytest -q`