### PR TITLE
Add parallel pipeline execution for multiple datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ configuration file in YAML (or JSON) format. A template is provided in
 python phase4.py --config config.yaml
 ```
 
+To analyse several dataset versions concurrently, list them after the
+``--datasets`` option. Results for each dataset are written to a subdirectory
+of ``output_dir``.
+
+```bash
+python phase4.py --config config.yaml --datasets raw cleaned_1 cleaned_3_multi cleaned_3_univ
+```
+
 
 Set `optimize_params: true` in the configuration to automatically tune the main
 hyperparameters of each dimensionality reduction method (number of components

--- a/phase4.py
+++ b/phase4.py
@@ -28,6 +28,7 @@ import logging
 import os
 from pathlib import Path
 from typing import Any, Dict, Mapping, Optional, Sequence
+from joblib import Parallel, delayed
 
 import matplotlib.pyplot as plt
 import pandas as pd
@@ -455,6 +456,30 @@ def run_pipeline(config: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
+def run_pipeline_parallel(
+    config: Dict[str, Any],
+    datasets: Sequence[str],
+    *,
+    n_jobs: Optional[int] = None,
+) -> Dict[str, Dict[str, Any]]:
+    """Run :func:`run_pipeline` on several datasets in parallel."""
+
+    def _single(name: str) -> tuple[str, Dict[str, Any]]:
+        cfg = dict(config)
+        cfg["dataset"] = name
+        if "output_dir" in cfg:
+            base = Path(cfg["output_dir"])
+            cfg["output_dir"] = str(base / name)
+        if "output_pdf" in cfg:
+            pdf = Path(cfg["output_pdf"])
+            cfg["output_pdf"] = str(pdf.with_name(f"{pdf.stem}_{name}{pdf.suffix}"))
+        return name, run_pipeline(cfg)
+
+    n_jobs = n_jobs or len(datasets)
+    results = Parallel(n_jobs=n_jobs)(delayed(_single)(ds) for ds in datasets)
+    return dict(results)
+
+
 # ---------------------------------------------------------------------------
 # CLI Entrypoint
 # ---------------------------------------------------------------------------
@@ -463,10 +488,24 @@ def run_pipeline(config: Dict[str, Any]) -> Dict[str, Any]:
 def main(argv: Optional[list[str]] = None) -> None:
     parser = argparse.ArgumentParser(description="Phase 4 analysis (modular)")
     parser.add_argument("--config", required=True, help="Path to config YAML/JSON")
+    parser.add_argument(
+        "--datasets",
+        nargs="+",
+        help="Datasets to process in parallel (e.g. raw cleaned_1)",
+    )
+    parser.add_argument(
+        "--dataset-jobs",
+        type=int,
+        default=None,
+        help="Number of workers for dataset-level parallelism",
+    )
     args = parser.parse_args(argv)
 
     cfg = _load_config(Path(args.config))
-    run_pipeline(cfg)
+    if args.datasets:
+        run_pipeline_parallel(cfg, args.datasets, n_jobs=args.dataset_jobs)
+    else:
+        run_pipeline(cfg)
 
 
 if __name__ == "__main__":  # pragma: no cover - manual execution

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -43,3 +43,22 @@ def test_run_pipeline_respects_optimize(tmp_path, monkeypatch):
 
     assert called.get("optimize") is False
     assert called.get("n_components") == 2
+
+
+def test_run_pipeline_parallel_calls(monkeypatch, tmp_path):
+    calls = {}
+
+    def fake_run_pipeline(cfg):
+        calls[cfg["dataset"]] = cfg["output_dir"]
+        return {}
+
+    monkeypatch.setattr(phase4, "run_pipeline", fake_run_pipeline)
+
+    cfg = {"output_dir": str(tmp_path / "out"), "input_file": "dummy"}
+    datasets = ["raw", "cleaned_1"]
+
+    res = phase4.run_pipeline_parallel(cfg, datasets, n_jobs=1)
+
+    assert set(res) == set(datasets)
+    for name in datasets:
+        assert Path(calls[name]).name == name


### PR DESCRIPTION
## Summary
- support processing several dataset versions in parallel via `run_pipeline_parallel`
- expose new `--datasets` CLI option in `phase4.py`
- document the feature in the README
- test the new helper

## Testing
- `pytest -q`