### PR TITLE
Add ignore_schema option for dataset loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ of ``output_dir``.
 python phase4.py --config config.yaml --datasets raw cleaned_1 cleaned_3_multi cleaned_3_univ
 ```
 
+If your pre-cleaned datasets do not share exactly the same columns as the raw
+file, set ``ignore_schema: true`` in the configuration. Missing columns will be
+added with ``NA`` values and extra columns will be discarded instead of raising
+a validation error during loading.
+
 
 Set `optimize_params: true` in the configuration to automatically tune the main
 hyperparameters of each dimensionality reduction method (number of components

--- a/config.yaml
+++ b/config.yaml
@@ -14,6 +14,7 @@ output_pdf: '\\Lenovo\d\DATAPREDICT\DATAPREDICT 2024\Missions\Digora\phase4_outp
 
 n_jobs: -1
 optimize_params: false
+ignore_schema: false
 methods: [famd, pca, mca, mfa, umap, pacmap, phate]
 
 # Method specific options (can be left empty)

--- a/phase4.py
+++ b/phase4.py
@@ -258,7 +258,7 @@ def run_pipeline(config: Dict[str, Any]) -> Dict[str, Any]:
     optimize = bool(config.get("optimize_params", False))
 
     logging.info("Loading datasets...")
-    datasets = load_datasets(config)
+    datasets = load_datasets(config, ignore_schema=bool(config.get("ignore_schema", False)))
     data_key = config.get("dataset", config.get("main_dataset", "raw"))
     if data_key not in datasets:
         raise KeyError(f"dataset '{data_key}' not found")

--- a/tests/test_load_datasets.py
+++ b/tests/test_load_datasets.py
@@ -86,3 +86,13 @@ def test_schema_check(tmp_path: Path):
 
     with pytest.raises(ValueError):
         pf.load_datasets(cfg)
+
+
+def test_schema_check_ignored(tmp_path: Path):
+    cfg = _make_sample_config(tmp_path)
+    df = pd.read_csv(cfg["input_file_cleaned_1"])
+    df["Extra"] = 1
+    df.to_csv(cfg["input_file_cleaned_1"], index=False)
+
+    datasets = pf.load_datasets(cfg, ignore_schema=True)
+    assert "Extra" not in datasets["cleaned_1"].columns


### PR DESCRIPTION
## Summary
- make dataset loading more flexible with `ignore_schema`
- mention ignore_schema usage in README
- expose ignore_schema in config
- ensure pipeline forwards ignore_schema setting
- test new behaviour

## Testing
- `pytest -q`