### PR TITLE
Fix Windows joblib spawn error

### DIFF
--- a/phase4.py
+++ b/phase4.py
@@ -471,21 +471,11 @@ def run_pipeline_parallel(
     backend: str = "multiprocessing",
 ) -> Dict[str, Dict[str, Any]]:
     """Run :func:`run_pipeline` on several datasets in parallel."""
-
-    def _single(name: str) -> tuple[str, Dict[str, Any]]:
-        cfg = dict(config)
-        cfg["dataset"] = name
-        if "output_dir" in cfg:
-            base = Path(cfg["output_dir"])
-            cfg["output_dir"] = str(base / name)
-        if "output_pdf" in cfg:
-            pdf = Path(cfg["output_pdf"])
-            cfg["output_pdf"] = str(pdf.with_name(f"{pdf.stem}_{name}{pdf.suffix}"))
-        return name, run_pipeline(cfg)
+    from phase4_parallel import _run_pipeline_single
 
     n_jobs = n_jobs or len(datasets)
     results = Parallel(n_jobs=n_jobs, backend=backend)(
-        delayed(_single)(ds) for ds in datasets
+        delayed(_run_pipeline_single)(config, ds) for ds in datasets
     )
     return dict(results)
 

--- a/phase4_parallel.py
+++ b/phase4_parallel.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Optional, Sequence
+
+from joblib import Parallel, delayed
+
+
+def _run_pipeline_single(config: Dict[str, Any], name: str) -> tuple[str, Dict[str, Any]]:
+    """Helper for :func:`run_pipeline_parallel` executing a single dataset."""
+
+    import phase4  # local import to avoid circular dependency
+
+    cfg = dict(config)
+    cfg["dataset"] = name
+    if "output_dir" in cfg:
+        base = Path(cfg["output_dir"])
+        cfg["output_dir"] = str(base / name)
+    if "output_pdf" in cfg:
+        pdf = Path(cfg["output_pdf"])
+        cfg["output_pdf"] = str(pdf.with_name(f"{pdf.stem}_{name}{pdf.suffix}"))
+    return name, phase4.run_pipeline(cfg)
+
+
+def run_pipeline_parallel(
+    config: Dict[str, Any],
+    datasets: Sequence[str],
+    *,
+    n_jobs: Optional[int] = None,
+    backend: str = "multiprocessing",
+) -> Dict[str, Dict[str, Any]]:
+    """Run :func:`phase4.run_pipeline` on several datasets in parallel."""
+
+    n_jobs = n_jobs or len(datasets)
+    results = Parallel(n_jobs=n_jobs, backend=backend)(
+        delayed(_run_pipeline_single)(config, ds) for ds in datasets
+    )
+    return dict(results)


### PR DESCRIPTION
## Summary
- move parallel helper to new `phase4_parallel` module
- wrap `run_pipeline_parallel` to use helper

## Testing
- `pytest -q`