### PR TITLE
Ajout de l'annexe des segments dans le PDF Phase 4

### DIFF
--- a/phase4.py
+++ b/phase4.py
@@ -220,6 +220,8 @@ def build_pdf_report(
         pdf.savefig(fig)
         plt.close(fig)
 
+        segments_dir = output_dir / "old" / "segments"
+
         for name in dataset_order:
             # Section page
             fig, ax = plt.subplots(figsize=(8.27, 11.69), dpi=200)
@@ -237,6 +239,8 @@ def build_pdf_report(
             for img in sorted(base_dir.rglob("*.png")):
                 if img.name == "methods_heatmap.png":
                     continue
+                if segments_dir.exists() and img.is_relative_to(segments_dir):
+                    continue
                 _add_image(pdf, img, name)
 
         heatmap_path = output_dir / "methods_heatmap.png"
@@ -248,6 +252,24 @@ def build_pdf_report(
                 fig = _table_to_fig(df, tname)
                 pdf.savefig(fig)
                 plt.close(fig)
+
+        if segments_dir.exists():
+            fig, ax = plt.subplots(figsize=(8.27, 11.69), dpi=200)
+            ax.axis("off")
+            ax.text(
+                0.5,
+                0.9,
+                "Annexe – Comptage des segments",
+                ha="center",
+                va="top",
+                fontsize=14,
+                weight="bold",
+            )
+            pdf.savefig(fig)
+            plt.close(fig)
+
+            for img in sorted(segments_dir.glob("*.png")):
+                _add_image(pdf, img, "Annexe")
 
     return pdf_path
 


### PR DESCRIPTION
## Notes
- Les images présentes dans `output_dir/old/segments` sont maintenant intégrées à la fin du PDF généré par `build_pdf_report`.
- Elles sont ignorées lors du parcours principal des figures afin d'apparaître en annexe seulement.

## Summary
- Skip `old/segments` figures when iterating over dataset images
- After tables, add a new section "Annexe – Comptage des segments" and append all PNG figures from this directory
- All tests pass (`37 passed`)
