### PR TITLE
Ajout de la concaténation des rapports PDF

### DIFF
--- a/tests/test_pdf_report.py
+++ b/tests/test_pdf_report.py
@@ -1,6 +1,7 @@
 import matplotlib.pyplot as plt
 from PyPDF2 import PdfReader
-from phase4 import build_pdf_report
+from matplotlib.backends.backend_pdf import PdfPages
+from phase4 import build_pdf_report, concat_pdf_reports
 
 
 def test_build_pdf_report(tmp_path):
@@ -24,3 +25,35 @@ def test_build_pdf_report(tmp_path):
     assert pdf_path.exists() and pdf_path.stat().st_size > 0
     reader = PdfReader(str(pdf_path))
     assert len(reader.pages) >= 5
+
+
+def test_concat_pdf_reports(tmp_path):
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+
+    names = [
+        "phase4_report_raw.pdf",
+        "phase4_report_cleaned_1.pdf",
+        "phase4_report_cleaned_3_univ.pdf",
+        "phase4_report_cleaned_3_multi.pdf",
+    ]
+
+    for name in names:
+        fig, ax = plt.subplots()
+        ax.plot([0, 1], [0, 1])
+        with PdfPages(out_dir / name) as pdf:
+            pdf.savefig(fig)
+        plt.close(fig)
+
+    seg_dir = out_dir / "old" / "segments"
+    seg_dir.mkdir(parents=True)
+    fig, ax = plt.subplots()
+    ax.plot([1, 2], [2, 1])
+    fig.savefig(seg_dir / "seg.png")
+    plt.close(fig)
+
+    final_pdf = tmp_path / "final.pdf"
+    concat_pdf_reports(out_dir, final_pdf)
+
+    reader = PdfReader(str(final_pdf))
+    assert len(reader.pages) == 6


### PR DESCRIPTION
## Notes
- Un utilitaire `concat_pdf_reports` permet désormais de fusionner les rapports `phase4_report_*.pdf` et d’y ajouter une annexe contenant toutes les figures PNG de `old/segments`.
- Les images sont converties en PDF grâce à la fonction interne `_images_to_pdf` avant d’être ajoutées à la fusion.
- Les tests couvrent ce nouveau comportement.

## Summary
- Revert segment handling inside `build_pdf_report`
- Add `_images_to_pdf` helper and new `concat_pdf_reports` function
- Extend `tests/test_pdf_report.py` with a test for PDF concatenation
- All tests pass (`38 passed`)
