### PR TITLE
Ajout fonction de concaténation des rapports PDF

### DIFF
--- a/phase4.py
+++ b/phase4.py
@@ -28,6 +28,10 @@ import logging
 import os
 from pathlib import Path
 from typing import Any, Dict, Mapping, Optional, Sequence
+import tempfile
+from contextlib import suppress
+
+from PyPDF2 import PdfMerger
 from joblib import Parallel, delayed
 
 import matplotlib.pyplot as plt
@@ -220,6 +224,8 @@ def build_pdf_report(
         pdf.savefig(fig)
         plt.close(fig)
 
+        segments_dir = output_dir / "old" / "segments"
+
         for name in dataset_order:
             # Section page
             fig, ax = plt.subplots(figsize=(8.27, 11.69), dpi=200)
@@ -237,6 +243,8 @@ def build_pdf_report(
             for img in sorted(base_dir.rglob("*.png")):
                 if img.name == "methods_heatmap.png":
                     continue
+                if segments_dir.exists() and img.is_relative_to(segments_dir):
+                    continue
                 _add_image(pdf, img, name)
 
         heatmap_path = output_dir / "methods_heatmap.png"
@@ -249,7 +257,82 @@ def build_pdf_report(
                 pdf.savefig(fig)
                 plt.close(fig)
 
+        if segments_dir.exists():
+            fig, ax = plt.subplots(figsize=(8.27, 11.69), dpi=200)
+            ax.axis("off")
+            ax.text(
+                0.5,
+                0.9,
+                "Annexe – Comptage des segments",
+                ha="center",
+                va="top",
+                fontsize=14,
+                weight="bold",
+            )
+            pdf.savefig(fig)
+            plt.close(fig)
+
+            for img in sorted(segments_dir.glob("*.png")):
+                _add_image(pdf, img, "Annexe")
+
     return pdf_path
+
+
+# ---------------------------------------------------------------------------
+# PDF concatenation helpers
+# ---------------------------------------------------------------------------
+
+def _images_to_pdf(images: Sequence[Path], pdf_path: Path) -> Path:
+    """Save all ``images`` into a simple PDF file."""
+    pdf_path.parent.mkdir(parents=True, exist_ok=True)
+    with PdfPages(pdf_path) as pdf:
+        for img in images:
+            if not img.exists():
+                continue
+            data = plt.imread(img)
+            fig, ax = plt.subplots(figsize=(8.27, 11.69), dpi=200)
+            ax.imshow(data)
+            ax.axis("off")
+            pdf.savefig(fig)
+            plt.close(fig)
+    return pdf_path
+
+
+def concat_pdf_reports(output_dir: Path, output_pdf: Path) -> Path:
+    """Concat predefined reports and append a segments annex."""
+
+    pdf_order = [
+        output_dir / "phase4_report_raw.pdf",
+        output_dir / "phase4_report_cleaned_1.pdf",
+        output_dir / "phase4_report_cleaned_3_univ.pdf",
+        output_dir / "phase4_report_cleaned_3_multi.pdf",
+    ]
+
+    merger = PdfMerger()
+    for path in pdf_order:
+        if path.exists():
+            merger.append(str(path))
+
+    segments_dir = output_dir / "old" / "segments"
+    tmp_pdf = None
+    if segments_dir.exists():
+        images = sorted(segments_dir.glob("*.png"))
+        if images:
+            with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
+                tmp_pdf = Path(tmp.name)
+            _images_to_pdf(images, tmp_pdf)
+            merger.append(str(tmp_pdf))
+
+    output_pdf.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_pdf, "wb") as fh:
+        merger.write(fh)
+    merger.close()
+
+    if tmp_pdf is not None:
+        with suppress(OSError):
+            os.remove(tmp_pdf)
+
+    return output_pdf
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pdf_report.py
+++ b/tests/test_pdf_report.py
@@ -1,6 +1,8 @@
 import matplotlib.pyplot as plt
+from matplotlib.backends.backend_pdf import PdfPages
+from pathlib import Path
 from PyPDF2 import PdfReader
-from phase4 import build_pdf_report
+from phase4 import build_pdf_report, concat_pdf_reports
 
 
 def test_build_pdf_report(tmp_path):
@@ -24,3 +26,41 @@ def test_build_pdf_report(tmp_path):
     assert pdf_path.exists() and pdf_path.stat().st_size > 0
     reader = PdfReader(str(pdf_path))
     assert len(reader.pages) >= 5
+
+
+def _make_simple_pdf(path: Path, text: str) -> None:
+    with PdfPages(path) as pdf:
+        fig, ax = plt.subplots()
+        ax.axis("off")
+        ax.text(0.5, 0.5, text, ha="center", va="center")
+        pdf.savefig(fig)
+        plt.close(fig)
+
+
+def test_concat_pdf_reports(tmp_path):
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+
+    names = [
+        "phase4_report_raw.pdf",
+        "phase4_report_cleaned_1.pdf",
+        "phase4_report_cleaned_3_univ.pdf",
+        "phase4_report_cleaned_3_multi.pdf",
+    ]
+
+    for i, name in enumerate(names):
+        _make_simple_pdf(out_dir / name, str(i))
+
+    seg_dir = out_dir / "old" / "segments"
+    seg_dir.mkdir(parents=True)
+    fig, ax = plt.subplots()
+    ax.plot([0, 1], [1, 0])
+    fig.savefig(seg_dir / "seg.png")
+    plt.close(fig)
+
+    final_pdf = tmp_path / "final.pdf"
+    concat_pdf_reports(out_dir, final_pdf)
+
+    assert final_pdf.exists() and final_pdf.stat().st_size > 0
+    reader = PdfReader(str(final_pdf))
+    assert len(reader.pages) == len(names) + 1


### PR DESCRIPTION
## Notes
- Nouvelle fonction `concat_pdf_reports` pour réunir les rapports de dataset et y ajouter en fin d'annexe toutes les figures de `old/segments`.
- Ajout du helper `_images_to_pdf` afin de transformer temporairement ces images en PDF.
- Mise à jour de `tests/test_pdf_report.py` pour couvrir cette concaténation.

## Summary
- Import de `PdfMerger` et `tempfile`
- Ajout de `_images_to_pdf` et `concat_pdf_reports` dans `phase4.py`
- Nouveau test `test_concat_pdf_reports`
- Tous les tests passent (`38 passed`)
