### PR TITLE
Fix missing cluster_k in metrics

### DIFF
--- a/phase4_functions.py
+++ b/phase4_functions.py
@@ -1774,6 +1774,7 @@ def evaluate_methods(
             "trustworthiness": T,
             "continuity": C,
             "runtime_seconds": runtime,
+            "cluster_k": best_k,
             "cluster_algo": algo,
         }
         return method, labels, row

--- a/tests/test_evaluate_methods.py
+++ b/tests/test_evaluate_methods.py
@@ -54,6 +54,7 @@ def test_evaluate_and_plot(tmp_path, monkeypatch):
         "trustworthiness",
         "continuity",
         "runtime_seconds",
+        "cluster_k",
         "cluster_algo",
     }
     assert set(metrics.columns) == expected_cols


### PR DESCRIPTION
## Summary
- include the chosen number of clusters in `evaluate_methods`
- update tests to expect new column

## Testing
- `pytest -q`