### PR TITLE
Add cluster vs segment mapping

### DIFF
--- a/old/dataset_comparison.py
+++ b/old/dataset_comparison.py
@@ -177,6 +177,7 @@ def compare_datasets_versions(
                 quant_vars,
                 qual_vars,
                 output_dir=fig_dir,
+                segment_col=None,
             )
         except Exception as exc:  # pragma: no cover - visualization failure
             logger.warning("Figure generation failed: %s", exc)

--- a/phase4.py
+++ b/phase4.py
@@ -592,6 +592,7 @@ def run_pipeline(config: Dict[str, Any]) -> Dict[str, Any]:
         quant_vars,
         qual_vars,
         output_dir=output_dir,
+        segment_col=config.get("segment_col"),
     )
 
     comparison_metrics = None

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -56,5 +56,15 @@ def test_generate_figures_handles_3d(tmp_path):
         ["cat"],
         output_dir=None,
         cluster_k=2,
+        segment_col="cat",
     )
     assert figs
+
+
+def test_cluster_segment_table_and_heatmap():
+    labels = np.array([0, 0, 1, 1, 0])
+    segs = pd.Series(["A", "B", "A", "A", "B"])
+    tab = pf.cluster_segment_table(labels, segs)
+    assert tab.loc[0, "A"] == 1
+    fig = pf.plot_cluster_segment_heatmap(tab, "test")
+    assert hasattr(fig, "savefig")


### PR DESCRIPTION
## Summary
- implement `cluster_segment_table` and heatmap drawing helper
- extend `generate_figures` with `segment_col` parameter and show heatmaps
- pass `segment_col` from `phase4.py`
- adapt dataset comparison script and tests
- test new utilities

## Testing
- `pytest -q`