### PR TITLE
Enable parallel figure generation

### DIFF
--- a/phase4.py
+++ b/phase4.py
@@ -708,6 +708,7 @@ def run_pipeline(config: Dict[str, Any]) -> Dict[str, Any]:
         qual_vars,
         output_dir=output_dir,
         segment_col=config.get("segment_col"),
+        n_jobs=n_jobs,
     )
 
     comparison_metrics = None


### PR DESCRIPTION
## Summary
- parallelize figure creation using joblib threads
- expose `n_jobs` option in `generate_figures`
- pass the pipeline thread count when generating figures

## Testing
- `pytest -q`