### PR TITLE
Ensure landscape orientation for PDF outputs

### DIFF
--- a/old/pdf_report.py
+++ b/old/pdf_report.py
@@ -91,7 +91,7 @@ def export_report_to_pdf(
     try:
         from fpdf import FPDF  # type: ignore
 
-        pdf = FPDF(format="A4", unit="mm")
+        pdf = FPDF(orientation="L", format="A4", unit="mm")
         pdf.set_auto_page_break(auto=True, margin=10)
 
         def _add_title(text: str, size: int = 14) -> None:
@@ -114,8 +114,7 @@ def export_report_to_pdf(
                     continue
             if not isinstance(table, pd.DataFrame):
                 continue
-            orientation = "L" if len(table.columns) > 6 else "P"
-            pdf.add_page(orientation=orientation)
+            pdf.add_page()
             _add_title(name)
             pdf.set_font("Courier", size=8)
             table_str = table.to_string()
@@ -151,7 +150,7 @@ def export_report_to_pdf(
         logger.info("FPDF not available, falling back to PdfPages")
 
         with PdfPages(out) as pdf_backend:
-            fig, ax = plt.subplots(figsize=(8.27, 11.69), dpi=200)
+            fig, ax = plt.subplots(figsize=(11.69, 8.27), dpi=200)
             today = datetime.datetime.now().strftime("%Y-%m-%d")
             ax.text(0.5, 0.6, "Rapport des analyses – Phase 4", fontsize=20, ha="center", va="center")
             ax.text(0.5, 0.4, f"Généré le {today}", fontsize=12, ha="center", va="center")

--- a/old/phase4v3.py
+++ b/old/phase4v3.py
@@ -1319,7 +1319,7 @@ def export_report_to_pdf(
     out.parent.mkdir(parents=True, exist_ok=True)
     logging.info("Exporting PDF report to %s", out)
     with PdfPages(out) as pdf:
-        fig, ax = plt.subplots(figsize=(8.27, 11.69), dpi=200)
+        fig, ax = plt.subplots(figsize=(11.69, 8.27), dpi=200)
         today = datetime.datetime.now().strftime("%Y-%m-%d")
         ax.text(0.5, 0.6, "Rapport des analyses – Phase 4", fontsize=20, ha="center", va="center")
         ax.text(0.5, 0.4, f"Généré le {today}", fontsize=12, ha="center", va="center")

--- a/phase3.py
+++ b/phase3.py
@@ -1467,8 +1467,8 @@ def generer_figures_synthese_phase3(out_dir,
     for i, png in enumerate(final_list, start=1):
         index_lines.append(f"Figure {i:02d} – {png.name}")
 
-    # Créer la figure d'index (A4 portrait)
-    fig, ax = _plt.subplots(figsize=(8.27, 11.69), dpi=200)
+    # Créer la figure d'index (A4 paysage)
+    fig, ax = _plt.subplots(figsize=(11.69, 8.27), dpi=200)
     ax.axis('off')
     ax.text(
         0.01, 0.99,

--- a/phase4.py
+++ b/phase4.py
@@ -165,7 +165,7 @@ def build_pdf_report(
 
     def _add_image(pdf: PdfPages, img_path: Path, dataset: str) -> None:
         img = plt.imread(img_path)
-        fig, ax = plt.subplots(figsize=(8.27, 11.69), dpi=200)
+        fig, ax = plt.subplots(figsize=(11.69, 8.27), dpi=200)
         ax.imshow(img)
         ax.axis("off")
         ax.text(
@@ -183,7 +183,8 @@ def build_pdf_report(
 
     def _table_to_fig(df: pd.DataFrame, title: str) -> plt.Figure:
         height = 0.4 * len(df) + 1.5
-        fig, ax = plt.subplots(figsize=(8.0, height), dpi=200)
+        fig_height = min(height, 8.27)
+        fig, ax = plt.subplots(figsize=(11.69, fig_height), dpi=200)
         ax.axis("off")
         ax.set_title(title)
         table = ax.table(
@@ -200,7 +201,7 @@ def build_pdf_report(
 
     with PdfPages(pdf_path) as pdf:
         # Title page
-        fig, ax = plt.subplots(figsize=(8.27, 11.69), dpi=200)
+        fig, ax = plt.subplots(figsize=(11.69, 8.27), dpi=200)
         ax.axis("off")
         ax.text(
             0.5,
@@ -262,7 +263,7 @@ def build_pdf_report(
 
         for name in dataset_order:
             # Section page
-            fig, ax = plt.subplots(figsize=(8.27, 11.69), dpi=200)
+            fig, ax = plt.subplots(figsize=(11.69, 8.27), dpi=200)
             ax.axis("off")
             ax.text(0.5, 0.9, name, ha="center", va="top", fontsize=14, weight="bold")
             pdf.savefig(fig)
@@ -302,7 +303,7 @@ def build_pdf_report(
                 plt.close(fig)
 
         if segments_dir.exists():
-            fig, ax = plt.subplots(figsize=(8.27, 11.69), dpi=200)
+            fig, ax = plt.subplots(figsize=(11.69, 8.27), dpi=200)
             ax.axis("off")
             ax.text(
                 0.5,
@@ -472,7 +473,7 @@ def _images_to_pdf(
     try:
         from fpdf import FPDF  # type: ignore
 
-        pdf = FPDF(format="A4", unit="mm")
+        pdf = FPDF(orientation="L", format="A4", unit="mm")
         pdf.set_auto_page_break(auto=False)
         if title:
             pdf.add_page()
@@ -494,7 +495,7 @@ def _images_to_pdf(
     except Exception:
         with PdfPages(pdf_path) as pdf:
             if title:
-                fig, ax = plt.subplots(figsize=(8.27, 11.69), dpi=200)
+                fig, ax = plt.subplots(figsize=(11.69, 8.27), dpi=200)
                 ax.axis("off")
                 ax.text(0.5, 0.9, title, ha="center", va="top", fontsize=14, weight="bold")
                 pdf.savefig(fig)
@@ -504,7 +505,7 @@ def _images_to_pdf(
                     continue
                 page_title, caption = _derive_seg_titles(img.name)
                 data = plt.imread(img)
-                fig, ax = plt.subplots(figsize=(8.27, 11.69), dpi=200)
+                fig, ax = plt.subplots(figsize=(11.69, 8.27), dpi=200)
                 ax.imshow(data)
                 ax.axis("off")
                 ax.set_title(page_title)

--- a/phase4_functions.py
+++ b/phase4_functions.py
@@ -3371,7 +3371,8 @@ def _table_to_figure(df: pd.DataFrame, title: str) -> plt.Figure:
     """
     # height grows with number of rows
     fig_height = 0.4 * len(df) + 1.5
-    fig, ax = plt.subplots(figsize=(8.0, fig_height), dpi=200)
+    fig_height = min(fig_height, 8.27)
+    fig, ax = plt.subplots(figsize=(11.69, fig_height), dpi=200)
     ax.axis("off")
     ax.set_title(title)
 
@@ -3457,7 +3458,7 @@ def export_report_to_pdf(
     try:
         from fpdf import FPDF  # type: ignore
 
-        pdf = FPDF(format="A4", unit="mm")
+        pdf = FPDF(orientation="L", format="A4", unit="mm")
         pdf.set_auto_page_break(auto=True, margin=10)
 
         def _add_title(text: str, size: int = 14) -> None:
@@ -3480,8 +3481,7 @@ def export_report_to_pdf(
                     continue
             if not isinstance(table, pd.DataFrame):
                 continue
-            orientation = "L" if len(table.columns) > 6 else "P"
-            pdf.add_page(orientation=orientation)
+            pdf.add_page()
             _add_title(name)
             pdf.set_font("Courier", size=8)
             table_str = table.to_string()
@@ -3517,7 +3517,7 @@ def export_report_to_pdf(
         logger.info("FPDF not available, falling back to PdfPages")
 
         with PdfPages(out) as pdf_backend:
-            fig, ax = plt.subplots(figsize=(8.27, 11.69), dpi=200)
+            fig, ax = plt.subplots(figsize=(11.69, 8.27), dpi=200)
             today = datetime.datetime.now().strftime("%Y-%m-%d")
             ax.text(
                 0.5,


### PR DESCRIPTION
## Summary
- set matplotlib figures to A4 landscape for PDF generation
- force FPDF documents to landscape orientation
- adjust table figure sizes accordingly
- update legacy scripts and Phase 3 index page for consistency

## Testing
- `pytest -q`