### PR TITLE
Improve parallelism and silence matplotlib warnings

### DIFF
--- a/phase4.py
+++ b/phase4.py
@@ -664,9 +664,15 @@ def run_pipeline(config: Dict[str, Any]) -> Dict[str, Any]:
         tasks.append(("pacmap", run_pacmap, (df_active,), params))
         nonlin_names.append("pacmap")
 
-    results = Parallel(n_jobs=n_jobs or len(tasks), prefer="threads")(
-        delayed(_run_method)(name, func, args, kwargs) for name, func, args, kwargs in tasks
-    )
+    backend = config.get("joblib_backend", "loky")
+    if len(tasks) <= 1 or (n_jobs is not None and n_jobs == 1):
+        results = [
+            _run_method(name, func, args, kwargs) for name, func, args, kwargs in tasks
+        ]
+    else:
+        results = Parallel(n_jobs=n_jobs or len(tasks), backend=backend)(
+            delayed(_run_method)(name, func, args, kwargs) for name, func, args, kwargs in tasks
+        )
 
     factor_results: Dict[str, Any] = {}
     nonlin_results: Dict[str, Any] = {}
@@ -709,6 +715,7 @@ def run_pipeline(config: Dict[str, Any]) -> Dict[str, Any]:
         output_dir=output_dir,
         segment_col=config.get("segment_col"),
         n_jobs=n_jobs,
+        backend=backend,
     )
 
     comparison_metrics = None

--- a/phase4_functions.py
+++ b/phase4_functions.py
@@ -25,6 +25,11 @@ import pandas as pd
 import warnings
 warnings.filterwarnings("ignore", category=RuntimeWarning)
 warnings.filterwarnings("ignore", category=FutureWarning)
+warnings.filterwarnings(
+    "ignore",
+    message="No handles with labels found to put in legend",
+    module="matplotlib",
+)
 
 
 def _read_dataset(path: Path) -> pd.DataFrame:
@@ -1803,7 +1808,9 @@ def plot_combined_silhouette(
     ax.set_xlabel("k")
     ax.set_ylabel("Silhouette")
     ax.set_title("Comparaison des méthodes – silhouette")
-    ax.legend()
+    handles, labels = ax.get_legend_handles_labels()
+    if labels:
+        ax.legend()
     fig.tight_layout()
     return fig
 
@@ -3025,6 +3032,7 @@ def generate_figures(
     cluster_k: int | None = None,
     segment_col: str | None = None,
     n_jobs: Optional[int] = None,
+    backend: str = "loky",
 ) -> Dict[str, plt.Figure]:
     """Generate and optionally save comparative visualization figures.
 
@@ -3042,6 +3050,9 @@ def generate_figures(
         each method.
     n_jobs : int or None, optional
         Number of parallel workers to use. Defaults to the number of methods.
+    backend : str, optional
+        Joblib backend used for parallelisation. Defaults to ``"loky"`` which
+        launches separate processes.
     """
     color_var = None
     figures: Dict[str, plt.Figure] = {}
@@ -3082,7 +3093,7 @@ def generate_figures(
         )
 
     n_jobs = n_jobs or len(tasks) or 1
-    for res_dict in Parallel(n_jobs=n_jobs, prefer="threads")(tasks):
+    for res_dict in Parallel(n_jobs=n_jobs, backend=backend)(tasks):
         figures.update(res_dict)
 
     return figures


### PR DESCRIPTION
## Summary
- add optional `joblib_backend` setting and call `Parallel` with that backend
- allow sequential fall back when only one task is run
- run figure generation with the selected backend
- ignore useless legend warnings and skip empty legend creation

## Testing
- `pytest -q`
