### PR TITLE
Add silhouette-Dunn summary plots

### DIFF
--- a/tests/test_factor_methods.py
+++ b/tests/test_factor_methods.py
@@ -51,4 +51,3 @@ def test_run_mfa_with_weights():
     groups = {"Num": ["num1", "num2"], "Cat": ["cat1", "cat2"]}
     res = pf.run_mfa(df, groups, optimize=True, weights={"Num": 2.0, "Cat": 1.0})
     assert res["embeddings"].shape[0] == len(df)
-

--- a/tests/test_method_params.py
+++ b/tests/test_method_params.py
@@ -24,4 +24,3 @@ def test_method_params_ignore_none():
     params = phase4._method_params("umap", cfg)
     assert params["metric"] == "cosine"
     assert params["n_neighbors"] == 30
-

--- a/tests/test_nonlin_methods.py
+++ b/tests/test_nonlin_methods.py
@@ -80,4 +80,3 @@ def test_run_pacmap_missing(monkeypatch):
     res = pf.run_pacmap(df)
     assert res["model"] is None
     assert res["embeddings"].empty
-

--- a/tests/test_threads.py
+++ b/tests/test_threads.py
@@ -13,4 +13,3 @@ def test_set_blas_threads_sets_env(monkeypatch):
     assert os.environ['OPENBLAS_NUM_THREADS'] == '3'
     assert os.environ['MKL_NUM_THREADS'] == '3'
     assert os.environ['OMP_NUM_THREADS'] == '3'
-

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -1,7 +1,6 @@
 import pandas as pd
 import numpy as np
 import phase4_functions as pf
-import matplotlib.pyplot as plt
 from sklearn.decomposition import PCA
 
 
@@ -80,7 +79,7 @@ def test_cluster_evaluation_and_stability_plots():
         df, best = pf.cluster_evaluation_metrics(X, method, range(2, 4))
         curves[method] = df
         opts[method] = best
-        fig = pf.plot_cluster_evaluation(df, method)
+        fig = pf.plot_cluster_evaluation(df, method, best)
         assert hasattr(fig, "savefig")
     comb = pf.plot_combined_silhouette(curves, opts)
     assert hasattr(comb, "savefig")


### PR DESCRIPTION
## Summary
- extend clustering evaluation plot with Dunn index bars and optimal k marker
- add `plot_analysis_summary` helper to combine analysis graphs
- generate summary page for each factor method
- include silhouette/Dunn plot in nonlinear method figures
- update visualization test accordingly

## Testing
- `pytest -q`