### PR TITLE
Add HDBSCAN clustering support and PDF report generator

### DIFF
--- a/RapportAnalyse.py
+++ b/RapportAnalyse.py
@@ -1,0 +1,15 @@
+import yaml
+from pathlib import Path
+import phase4_functions as pf
+
+
+def main():
+    with open("config.yaml", "r", encoding="utf-8") as fh:
+        config = yaml.safe_load(fh)
+    datasets = pf.load_datasets(config, ignore_schema=True)
+    result = pf.compare_datasets_versions(datasets, output_dir=Path("rapport_output"))
+    pf.build_pdf_report(Path("rapport_output"), Path("RapportAnalyse.pdf"), list(datasets))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add HDBSCAN evaluation and optimisation helpers
- support HDBSCAN in clustering visualisations
- new stacked metric figure for clustering validation curves
- fallback to DBSCAN when hdbscan isn't installed
- simple script `RapportAnalyse.py` to build the final PDF report

## Testing
- `pytest -q`