### PR TITLE
Add segment analysis pages

### DIFF
--- a/tests/test_pdf_report.py
+++ b/tests/test_pdf_report.py
@@ -41,7 +41,7 @@ def test_build_pdf_report(tmp_path):
 
     assert pdf_path.exists() and pdf_path.stat().st_size > 0
     reader = PdfReader(str(pdf_path))
-    assert len(reader.pages) == 11
+    assert len(reader.pages) == 13
 
 
 def _make_simple_pdf(path: Path, text: str) -> None:


### PR DESCRIPTION
## Summary
- extend build_pdf_report with two pages of business segment plots
- generate the new pages when running the pipeline
- adjust PDF report test for new page count

## Testing
- `pytest -q`