### PR TITLE
Add global metrics heatmap to PDF report

### DIFF
--- a/tests/test_pdf_report.py
+++ b/tests/test_pdf_report.py
@@ -36,12 +36,18 @@ def test_build_pdf_report(tmp_path):
     fig.savefig(comp_dir / "pca_analysis_summary.png")
     plt.close(fig)
 
+    fig, ax = plt.subplots()
+    ax.imshow([[0, 1], [1, 0]])
+    ax.axis("off")
+    fig.savefig(out_dir / "general_heatmap.png")
+    plt.close(fig)
+
     pdf_path = tmp_path / "report.pdf"
     build_pdf_report(out_dir, pdf_path, ["main", "v1"], {})
 
     assert pdf_path.exists() and pdf_path.stat().st_size > 0
     reader = PdfReader(str(pdf_path))
-    assert len(reader.pages) == 13
+    assert len(reader.pages) == 14
 
 
 def _make_simple_pdf(path: Path, text: str) -> None:

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -66,6 +66,7 @@ def test_run_pipeline_parallel_calls(monkeypatch, tmp_path):
         return wrapper
 
     monkeypatch.setattr(phase4, "run_pipeline", fake_run_pipeline)
+    monkeypatch.setattr(phase4, "plot_general_heatmap", lambda *a, **k: None)
     monkeypatch.setattr(phase4, "Parallel", FakeParallel)
     monkeypatch.setattr(phase4, "delayed", fake_delayed)
 
@@ -113,6 +114,7 @@ def test_run_pipeline_parallel_concats_reports(monkeypatch, tmp_path):
         return pdf_path
 
     monkeypatch.setattr(phase4, "run_pipeline", fake_run_pipeline)
+    monkeypatch.setattr(phase4, "plot_general_heatmap", lambda *a, **k: None)
     monkeypatch.setattr(phase4, "concat_pdf_reports", fake_concat)
     monkeypatch.setattr(phase4, "Parallel", FakeParallel)
     monkeypatch.setattr(phase4, "delayed", fake_delayed)


### PR DESCRIPTION
## Summary
- generate a general heatmap across all datasets and methods
- embed the general heatmap at the end of each PDF report
- include the global figure when concatenating multiple reports
- ensure run_pipeline_parallel compiles metrics for the summary
- update unit tests for the new page

## Testing
- `pytest -q`