### PR TITLE
Fix clustering visualization and remove redundant metrics table

### DIFF
--- a/phase4.py
+++ b/phase4.py
@@ -44,6 +44,7 @@ from matplotlib.backends.backend_pdf import PdfPages
 from PyPDF2 import PdfMerger
 
 import warnings
+
 warnings.filterwarnings("ignore", category=RuntimeWarning)
 warnings.filterwarnings("ignore", category=FutureWarning)
 
@@ -124,8 +125,6 @@ def set_blas_threads(n_jobs: int = -1) -> int:
     ]:
         os.environ[var] = str(n_jobs)
     return n_jobs
-
-
 
 
 def build_pdf_report(
@@ -279,10 +278,7 @@ def build_pdf_report(
                     "*clusters_dbscan*.png",
                     "*clusters_gmm*.png",
                 ]
-                imgs = [
-                    _first_image(method_dir, pat)
-                    for pat in pats
-                ]
+                imgs = [_first_image(method_dir, pat) for pat in pats]
                 if not any(imgs):
                     return
                 fig, axes = plt.subplots(2, 2, figsize=(11, 8.5), dpi=200)
@@ -345,7 +341,6 @@ def build_pdf_report(
                 _add_cluster_page(method_dir, name)
                 _add_analysis_page(method_dir, name)
 
-
         heatmap_path = output_dir / "methods_heatmap.png"
         if heatmap_path.exists():
             _add_image(pdf, heatmap_path, dataset_order[0])
@@ -366,7 +361,14 @@ def build_pdf_report(
             else:
                 fig, ax = plt.subplots(figsize=(11.69, 8.27), dpi=200)
                 ax.axis("off")
-                ax.text(0.5, 0.5, f"{title} (donn\xe9es manquantes)", ha="center", va="center", fontsize=12)
+                ax.text(
+                    0.5,
+                    0.5,
+                    f"{title} (donn\xe9es manquantes)",
+                    ha="center",
+                    va="center",
+                    fontsize=12,
+                )
             pdf.savefig(fig)
             plt.close(fig)
 
@@ -375,7 +377,9 @@ def build_pdf_report(
         _add_segment_page(seg1, "Synth\xe8se segmentaire 1")
         _add_segment_page(seg2, "Synth\xe8se segmentaire 2")
 
-        def _segment_analysis_pages(data: Optional[pd.DataFrame]) -> tuple[plt.Figure, plt.Figure]:
+        def _segment_analysis_pages(
+            data: Optional[pd.DataFrame],
+        ) -> tuple[plt.Figure, plt.Figure]:
             seg_cols1 = [
                 "Cat\xe9gorie",
                 "Sous-cat\xe9gorie",
@@ -400,7 +404,14 @@ def build_pdf_report(
                     _plot(ax, data[col], col)
                 else:
                     ax.axis("off")
-                    ax.text(0.5, 0.5, "Donn\xe9es manquantes", ha="center", va="center", fontsize=8)
+                    ax.text(
+                        0.5,
+                        0.5,
+                        "Donn\xe9es manquantes",
+                        ha="center",
+                        va="center",
+                        fontsize=8,
+                    )
             fig1.tight_layout()
 
             fig2, axes2 = plt.subplots(2, 2, figsize=(11.69, 8.27), dpi=200)
@@ -409,7 +420,14 @@ def build_pdf_report(
                     _plot(ax, data[col], col)
                 else:
                     ax.axis("off")
-                    ax.text(0.5, 0.5, "Donn\xe9es manquantes", ha="center", va="center", fontsize=8)
+                    ax.text(
+                        0.5,
+                        0.5,
+                        "Donn\xe9es manquantes",
+                        ha="center",
+                        va="center",
+                        fontsize=8,
+                    )
 
             ax = axes2.ravel()[3]
             if data is not None:
@@ -424,10 +442,24 @@ def build_pdf_report(
                     ax.set_xlabel("Segment")
                 else:
                     ax.axis("off")
-                    ax.text(0.5, 0.5, "Donn\xe9es manquantes", ha="center", va="center", fontsize=8)
+                    ax.text(
+                        0.5,
+                        0.5,
+                        "Donn\xe9es manquantes",
+                        ha="center",
+                        va="center",
+                        fontsize=8,
+                    )
             else:
                 ax.axis("off")
-                ax.text(0.5, 0.5, "Donn\xe9es manquantes", ha="center", va="center", fontsize=8)
+                ax.text(
+                    0.5,
+                    0.5,
+                    "Donn\xe9es manquantes",
+                    ha="center",
+                    va="center",
+                    fontsize=8,
+                )
 
             fig2.tight_layout()
             return fig1, fig2
@@ -465,9 +497,7 @@ def build_pdf_report(
     return pdf_path
 
 
-def build_type_report(
-    base_dir: Path, pdf_path: Path, datasets: Sequence[str]
-) -> Path:
+def build_type_report(base_dir: Path, pdf_path: Path, datasets: Sequence[str]) -> Path:
     """Assemble figures by type in landscape orientation.
 
     Figures are grouped in the following order: scatter plots, correlation
@@ -574,7 +604,9 @@ def build_type_report(
         if any(v for v in annex_images.values()):
             fig, ax = plt.subplots(figsize=page_size, dpi=200)
             ax.axis("off")
-            ax.text(0.5, 0.9, "Annexe", ha="center", va="top", fontsize=14, weight="bold")
+            ax.text(
+                0.5, 0.9, "Annexe", ha="center", va="top", fontsize=14, weight="bold"
+            )
             pdf.savefig(fig)
             plt.close(fig)
 
@@ -583,7 +615,9 @@ def build_type_report(
             if annex_images["heatmaps"]:
                 _grid_page(pdf, annex_images["heatmaps"], "Clusters vs Segments")
             if annex_images["cluster_validation"]:
-                _grid_page(pdf, annex_images["cluster_validation"], "Validation clustering")
+                _grid_page(
+                    pdf, annex_images["cluster_validation"], "Validation clustering"
+                )
 
     return pdf_path
 
@@ -591,6 +625,7 @@ def build_type_report(
 # ---------------------------------------------------------------------------
 # PDF concatenation helpers
 # ---------------------------------------------------------------------------
+
 
 def _derive_seg_titles(filename: str) -> tuple[str, str]:
     """Return a title and caption for a segment figure filename."""
@@ -639,7 +674,9 @@ def _images_to_pdf(
             if title:
                 fig, ax = plt.subplots(figsize=(11.69, 8.27), dpi=200)
                 ax.axis("off")
-                ax.text(0.5, 0.9, title, ha="center", va="top", fontsize=14, weight="bold")
+                ax.text(
+                    0.5, 0.9, title, ha="center", va="top", fontsize=14, weight="bold"
+                )
                 pdf.savefig(fig)
                 plt.close(fig)
             for img in images:
@@ -697,7 +734,9 @@ def concat_pdf_reports(output_dir: Path, output_pdf: Path) -> Path:
         if images:
             with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
                 tmp_pdf = Path(tmp.name)
-            _images_to_pdf(images, tmp_pdf, "Appendix – Business Segment Visualizations")
+            _images_to_pdf(
+                images, tmp_pdf, "Appendix – Business Segment Visualizations"
+            )
             merger.append(str(tmp_pdf))
 
     output_pdf.parent.mkdir(parents=True, exist_ok=True)
@@ -728,7 +767,9 @@ def run_pipeline(config: Dict[str, Any]) -> Dict[str, Any]:
     optimize = bool(config.get("optimize_params", False))
 
     logging.info("Loading datasets...")
-    datasets = load_datasets(config, ignore_schema=bool(config.get("ignore_schema", False)))
+    datasets = load_datasets(
+        config, ignore_schema=bool(config.get("ignore_schema", False))
+    )
     data_key = config.get("dataset", config.get("main_dataset", "raw"))
     if data_key not in datasets:
         raise KeyError(f"dataset '{data_key}' not found")
@@ -773,21 +814,32 @@ def run_pipeline(config: Dict[str, Any]) -> Dict[str, Any]:
         params = _method_params("pca", config)
         if optimize:
             params.pop("n_components", None)
-        tasks.append(("pca", run_pca, (df_active, quant_vars), dict(optimize=optimize, **params)))
+        tasks.append(
+            ("pca", run_pca, (df_active, quant_vars), dict(optimize=optimize, **params))
+        )
         factor_names.append("pca")
 
     if "mca" in methods and qual_vars:
         params = _method_params("mca", config)
         if optimize:
             params.pop("n_components", None)
-        tasks.append(("mca", run_mca, (df_active, qual_vars), dict(optimize=optimize, **params)))
+        tasks.append(
+            ("mca", run_mca, (df_active, qual_vars), dict(optimize=optimize, **params))
+        )
         factor_names.append("mca")
 
     if "famd" in methods and quant_vars and qual_vars:
         params = _method_params("famd", config)
         if optimize:
             params.pop("n_components", None)
-        tasks.append(("famd", run_famd, (df_active, quant_vars, qual_vars), dict(optimize=optimize, **params)))
+        tasks.append(
+            (
+                "famd",
+                run_famd,
+                (df_active, quant_vars, qual_vars),
+                dict(optimize=optimize, **params),
+            )
+        )
         factor_names.append("famd")
 
     groups = []
@@ -802,7 +854,9 @@ def run_pipeline(config: Dict[str, Any]) -> Dict[str, Any]:
         cfg_groups = params.pop("groups", None)
         if cfg_groups:
             groups = cfg_groups
-        tasks.append(("mfa", run_mfa, (df_active, groups), dict(optimize=optimize, **params)))
+        tasks.append(
+            ("mfa", run_mfa, (df_active, groups), dict(optimize=optimize, **params))
+        )
         factor_names.append("mfa")
 
     if "umap" in methods:
@@ -825,7 +879,8 @@ def run_pipeline(config: Dict[str, Any]) -> Dict[str, Any]:
         ]
     else:
         results = Parallel(n_jobs=n_jobs or len(tasks), backend=backend)(
-            delayed(_run_method)(name, func, args, kwargs) for name, func, args, kwargs in tasks
+            delayed(_run_method)(name, func, args, kwargs)
+            for name, func, args, kwargs in tasks
         )
 
     factor_results: Dict[str, Any] = {}
@@ -910,7 +965,7 @@ def run_pipeline(config: Dict[str, Any]) -> Dict[str, Any]:
 
     if config.get("output_pdf"):
         logging.info("Building PDF report...")
-        tables: Dict[str, pd.DataFrame] = {"metrics": format_metrics_table(metrics)}
+        tables: Dict[str, pd.DataFrame] = {}
         if comparison_metrics is not None:
             tables["comparison_metrics"] = format_metrics_table(comparison_metrics)
         if robustness_df is not None:
@@ -933,7 +988,9 @@ def run_pipeline(config: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
-def _run_pipeline_single(config: Dict[str, Any], name: str) -> tuple[str, Dict[str, Any]]:
+def _run_pipeline_single(
+    config: Dict[str, Any], name: str
+) -> tuple[str, Dict[str, Any]]:
     """Helper for :func:`run_pipeline_parallel` executing a single dataset."""
 
     cfg = dict(config)
@@ -973,7 +1030,9 @@ def run_pipeline_parallel(
 
     if metrics_frames:
         all_metrics = pd.concat(metrics_frames, ignore_index=True)
-        plot_general_heatmap(all_metrics, Path(config.get("output_dir", "phase4_output")))
+        plot_general_heatmap(
+            all_metrics, Path(config.get("output_dir", "phase4_output"))
+        )
 
     if "output_pdf" in config:
         base_dir = Path(config.get("output_dir", "phase4_output"))

--- a/phase4_functions.py
+++ b/phase4_functions.py
@@ -17,12 +17,14 @@ from pathlib import Path
 from typing import Any, Dict, Mapping, Optional
 
 import os
+
 # limite OpenBLAS à 24 threads (ou moins)
 os.environ["OPENBLAS_NUM_THREADS"] = "24"
 
 import pandas as pd
 
 import warnings
+
 warnings.filterwarnings("ignore", category=RuntimeWarning)
 warnings.filterwarnings("ignore", category=FutureWarning)
 warnings.filterwarnings(
@@ -967,7 +969,11 @@ def run_famd(
     if zero_std:
         logger.warning("Variables constantes exclues du scaling : %s", zero_std)
         quant_vars = [c for c in quant_vars if c not in zero_std]
-    X_quanti = scaler.fit_transform(df_active[quant_vars]) if quant_vars else np.empty((len(df_active), 0))
+    X_quanti = (
+        scaler.fit_transform(df_active[quant_vars])
+        if quant_vars
+        else np.empty((len(df_active), 0))
+    )
     df_quanti = pd.DataFrame(X_quanti, index=df_active.index, columns=quant_vars)
     df_mix = pd.concat([df_quanti, df_active[qual_vars].astype("category")], axis=1)
 
@@ -1166,7 +1172,9 @@ def run_mfa(
     mfa = mfa.fit(df_all, groups=groups_dict)
     inertia_values = np.asarray(mfa.percentage_of_variance_, dtype=float) / 100
     inertia_values = (
-        inertia_values / inertia_values.sum() if inertia_values.sum() > 0 else inertia_values
+        inertia_values / inertia_values.sum()
+        if inertia_values.sum() > 0
+        else inertia_values
     )
     mfa.explained_inertia_ = inertia_values
     embeddings = mfa.row_coordinates(df_all)
@@ -1717,7 +1725,9 @@ def cluster_evaluation_metrics(
         elif method == "agglomerative":
             labels = AgglomerativeClustering(n_clusters=k).fit_predict(X)
         elif method == "gmm":
-            labels = GaussianMixture(n_components=k, covariance_type="full").fit_predict(X)
+            labels = GaussianMixture(
+                n_components=k, covariance_type="full"
+            ).fit_predict(X)
         else:
             raise ValueError(f"Unknown method '{method}'")
 
@@ -1791,7 +1801,9 @@ def optimize_clusters(
     elif method == "agglomerative":
         labels = AgglomerativeClustering(n_clusters=best_k).fit_predict(X)
     elif method == "gmm":
-        labels = GaussianMixture(n_components=best_k, covariance_type="full").fit_predict(X)
+        labels = GaussianMixture(
+            n_components=best_k, covariance_type="full"
+        ).fit_predict(X)
     else:  # pragma: no cover - defensive
         raise ValueError(f"Unknown method '{method}'")
 
@@ -1813,7 +1825,14 @@ def dbscan_evaluation_metrics(
         labels = DBSCAN(eps=eps, min_samples=min_samples).fit_predict(X)
         n_clusters = len(set(labels)) - (1 if -1 in labels else 0)
         if n_clusters < 2:
-            return eps, float("nan"), float("nan"), float("nan"), float("nan"), n_clusters
+            return (
+                eps,
+                float("nan"),
+                float("nan"),
+                float("nan"),
+                float("nan"),
+                n_clusters,
+            )
         samples = silhouette_samples(X, labels)
         sil_mean = float(samples.mean())
         sil_err = 1.96 * samples.std(ddof=1) / np.sqrt(len(samples))
@@ -1845,7 +1864,11 @@ def dbscan_evaluation_metrics(
 
     df = pd.DataFrame.from_records(records)
     if best_eps is None:
-        best_eps = float(df.loc[df["silhouette"].idxmax(), "eps"]) if not df.empty else next(iter(eps_values), 0.5)
+        best_eps = (
+            float(df.loc[df["silhouette"].idxmax(), "eps"])
+            if not df.empty
+            else next(iter(eps_values), 0.5)
+        )
     return df.sort_values("eps"), float(best_eps)
 
 
@@ -1892,14 +1915,6 @@ def plot_cluster_evaluation(
         color="tab:blue",
         label="Silhouette",
     )
-    if {"silhouette_lower", "silhouette_upper"}.issubset(df.columns):
-        ax1.fill_between(
-            df[xcol],
-            df["silhouette_lower"],
-            df["silhouette_upper"],
-            color="tab:blue",
-            alpha=0.2,
-        )
     ax2.bar(
         df[xcol],
         df["dunn_index"],
@@ -1950,9 +1965,7 @@ def hdbscan_evaluation_metrics(
         return mcs, ms, sil_mean, sil_mean - sil_err, sil_mean + sil_err, dunn
 
     results = Parallel(n_jobs=-1)(
-        delayed(_eval)(mcs, ms)
-        for mcs in mcs_values
-        for ms in min_samples_values
+        delayed(_eval)(mcs, ms) for mcs in mcs_values for ms in min_samples_values
     )
 
     records: list[dict[str, float]] = []
@@ -2003,9 +2016,7 @@ def optimize_hdbscan_clusters(
         )
         import hdbscan  # type: ignore
 
-        clusterer = hdbscan.HDBSCAN(
-            min_cluster_size=best[0], min_samples=best[1]
-        )
+        clusterer = hdbscan.HDBSCAN(min_cluster_size=best[0], min_samples=best[1])
         labels = clusterer.fit_predict(X)
         return labels, best, curves
     except Exception:
@@ -2023,10 +2034,10 @@ def optimize_hdbscan_clusters(
 def plot_cluster_metrics_grid(
     curves: Mapping[str, pd.DataFrame], optimal: Mapping[str, int]
 ) -> plt.Figure:
-    """Return a figure with silhouette/Dunn curves stacked vertically."""
-    fig, axes = plt.subplots(4, 1, figsize=(6, 12), dpi=200)
+    """Return a figure with silhouette/Dunn curves."""
+    fig, axes = plt.subplots(2, 2, figsize=(12, 6), dpi=200)
     methods = ["kmeans", "agglomerative", "gmm", "hdbscan"]
-    for ax, method in zip(axes, methods):
+    for ax, method in zip(axes.ravel(), methods):
         df = curves.get(method)
         if df is None or df.empty:
             ax.axis("off")
@@ -2034,14 +2045,7 @@ def plot_cluster_metrics_grid(
         ax2 = ax.twinx()
         xcol = "k" if "k" in df.columns else "min_cluster_size"
         ax.plot(df[xcol], df["silhouette"], marker="o", color="tab:blue")
-        if {"silhouette_lower", "silhouette_upper"}.issubset(df.columns):
-            ax.fill_between(
-                df[xcol],
-                df["silhouette_lower"],
-                df["silhouette_upper"],
-                color="tab:blue",
-                alpha=0.2,
-            )
+        # Removed confidence interval shading for clarity
         ax2.bar(df[xcol], df["dunn_index"], color="tab:orange", alpha=0.3)
         k_opt = optimal.get(method)
         if k_opt is not None and k_opt in df[xcol].values:
@@ -2066,13 +2070,7 @@ def plot_combined_silhouette(
             continue
         df = df.sort_values("k")
         ax.plot(df["k"], df["silhouette"], marker="o", label=method)
-        if {"silhouette_lower", "silhouette_upper"}.issubset(df.columns):
-            ax.fill_between(
-                df["k"],
-                df["silhouette_lower"],
-                df["silhouette_upper"],
-                alpha=0.2,
-            )
+        # interval shading removed
         k_opt = optimal_k.get(method)
         if k_opt is not None and k_opt in df["k"].values:
             val = float(df.loc[df["k"] == k_opt, "silhouette"].iloc[0])
@@ -2122,13 +2120,15 @@ def plot_analysis_summary(
 
 
 def plot_pca_stability_bars(
-    metrics: Mapping[str, Mapping[str, float]]
+    metrics: Mapping[str, Mapping[str, float]],
 ) -> Dict[str, plt.Figure]:
     """Return bar charts summarising PCA cross-validation stability."""
 
     datasets = list(metrics)
     axis_corr = [metrics[d].get("pca_axis_corr_mean", float("nan")) for d in datasets]
-    var_first = [metrics[d].get("pca_var_first_axis_mean", float("nan")) for d in datasets]
+    var_first = [
+        metrics[d].get("pca_var_first_axis_mean", float("nan")) for d in datasets
+    ]
 
     fig1, ax1 = plt.subplots(figsize=(6, 4), dpi=200)
     ax1.bar(datasets, axis_corr, color="tab:blue", edgecolor="black")
@@ -2185,7 +2185,9 @@ def evaluate_methods(
 
     logger = logging.getLogger(__name__)
 
-    def _process(item: tuple[str, Dict[str, Any]]) -> tuple[str, np.ndarray, str, Dict[str, Any]]:
+    def _process(
+        item: tuple[str, Dict[str, Any]],
+    ) -> tuple[str, np.ndarray, str, Dict[str, Any]]:
         method, info = item
 
         inertias = info.get("inertia")
@@ -2268,7 +2270,9 @@ def evaluate_methods(
         }
         return method, labels, row
 
-    parallel_res = Parallel(n_jobs=-1)(delayed(_process)(it) for it in results_dict.items())
+    parallel_res = Parallel(n_jobs=-1)(
+        delayed(_process)(it) for it in results_dict.items()
+    )
     rows = []
     for method, labels, row in parallel_res:
         results_dict[method]["cluster_labels"] = labels
@@ -2315,7 +2319,10 @@ def plot_methods_heatmap(df_metrics: pd.DataFrame, output_path: str | Path) -> N
     if "nb_axes_kaiser" in annot:
         annot["nb_axes_kaiser"] = annot["nb_axes_kaiser"].astype("Int64")
     for col in annot.columns:
-        if col not in {"variance_cumulee_%", "nb_axes_kaiser"} and pd.api.types.is_numeric_dtype(annot[col]):
+        if col not in {
+            "variance_cumulee_%",
+            "nb_axes_kaiser",
+        } and pd.api.types.is_numeric_dtype(annot[col]):
             annot[col] = annot[col].map(lambda x: f"{x:.2f}" if pd.notna(x) else "")
 
     fig, ax = plt.subplots(figsize=(12, 6), dpi=200)
@@ -2363,7 +2370,9 @@ def plot_general_heatmap(df_metrics: pd.DataFrame, output_path: str | Path) -> N
 
     annot = df_numeric.copy()
     if "variance_cumulee_%" in annot:
-        annot["variance_cumulee_%"] = annot["variance_cumulee_%"].round().astype("Int64")
+        annot["variance_cumulee_%"] = (
+            annot["variance_cumulee_%"].round().astype("Int64")
+        )
     if "nb_axes_kaiser" in annot:
         annot["nb_axes_kaiser"] = annot["nb_axes_kaiser"].astype("Int64")
     for col in annot.columns:
@@ -2371,7 +2380,9 @@ def plot_general_heatmap(df_metrics: pd.DataFrame, output_path: str | Path) -> N
             annot[col] = annot[col].map(lambda x: f"{x:.2f}" if pd.notna(x) else "")
 
     fig, ax = plt.subplots(figsize=(12, 8), dpi=200)
-    sns.heatmap(norm, annot=annot, fmt="", cmap="coolwarm", vmin=0, vmax=1, ax=ax, cbar=False)
+    sns.heatmap(
+        norm, annot=annot, fmt="", cmap="coolwarm", vmin=0, vmax=1, ax=ax, cbar=False
+    )
     ax.set_title("Synthèse globale des métriques")
     ax.set_xticklabels(ax.get_xticklabels(), rotation=45, ha="right")
     ax.set_ylabel("Dataset – Méthode")
@@ -2458,7 +2469,9 @@ def plot_correlation_circle(
     # preserving their relative lengths.
     fig, ax = plt.subplots(figsize=(6, 6), dpi=200)
 
-    if not any(isinstance(p, plt.Circle) and np.isclose(p.radius, scale) for p in ax.patches):
+    if not any(
+        isinstance(p, plt.Circle) and np.isclose(p.radius, scale) for p in ax.patches
+    ):
         circle = plt.Circle((0, 0), scale, color="grey", fill=False, linestyle="dashed")
         ax.add_patch(circle)
     ax.axhline(0, color="grey", lw=0.5)
@@ -2504,7 +2517,6 @@ def plot_correlation_circle(
     ax.set_ylim(-limit, limit)
     ax.set_xlabel("F1")
     ax.set_ylabel("F2")
-
 
     method_name = factor_model.__class__.__name__.upper()
     if hasattr(factor_model, "explained_variance_ratio_"):
@@ -2740,8 +2752,6 @@ def plot_cluster_scatter(
     return fig
 
 
-
-
 def plot_cluster_distribution(labels: np.ndarray, title: str) -> plt.Figure:
     """Return a bar chart showing the count of points per cluster."""
     unique, counts = np.unique(labels, return_counts=True)
@@ -2844,9 +2854,7 @@ def cluster_segment_table(
     return pd.crosstab(ser_labels, ser_segments)
 
 
-def plot_cluster_segment_heatmap(
-    table: pd.DataFrame, title: str
-) -> plt.Figure:
+def plot_cluster_segment_heatmap(table: pd.DataFrame, title: str) -> plt.Figure:
     """Return a heatmap visualising ``table`` counts."""
     import seaborn as sns
 
@@ -2868,7 +2876,9 @@ def segment_profile_table(
     if segment_col not in df.columns:
         raise KeyError(segment_col)
     if variables is None:
-        variables = [c for c in df.select_dtypes(include="number").columns if c != segment_col]
+        variables = [
+            c for c in df.select_dtypes(include="number").columns if c != segment_col
+        ]
     if not variables:
         return pd.DataFrame(index=df[segment_col].unique())
     table = df.groupby(segment_col)[list(variables)].mean()
@@ -2931,15 +2941,21 @@ def generate_scatter_plots(
     plt.close(fig)
     result["no_cluster_2d"] = path
 
-    labels, k = tune_kmeans_clusters(emb.iloc[:, :2].values, range(2, min(15, len(emb))))
+    labels, k = tune_kmeans_clusters(
+        emb.iloc[:, :2].values, range(2, min(15, len(emb)))
+    )
     fig = plot_cluster_scatter(emb.iloc[:, :2], labels, f"{title} – KMeans (k={k})")
     path = out_dir / "kmeans_2d.png"
     fig.savefig(path, dpi=300)
     plt.close(fig)
     result["kmeans_2d"] = path
 
-    labels, k = tune_agglomerative_clusters(emb.iloc[:, :2].values, range(2, min(15, len(emb))))
-    fig = plot_cluster_scatter(emb.iloc[:, :2], labels, f"{title} – Agglomerative (k={k})")
+    labels, k = tune_agglomerative_clusters(
+        emb.iloc[:, :2].values, range(2, min(15, len(emb)))
+    )
+    fig = plot_cluster_scatter(
+        emb.iloc[:, :2], labels, f"{title} – Agglomerative (k={k})"
+    )
     path = out_dir / "agglomerative_2d.png"
     fig.savefig(path, dpi=300)
     plt.close(fig)
@@ -3070,9 +3086,7 @@ def plot_famd_contributions(contrib: pd.DataFrame, n: int = 10) -> plt.Figure:
     for idx in contrib.index:
         var = idx.split("__", 1)[0]
         grouped.setdefault(var, pd.Series(dtype=float))
-        grouped[var] = grouped[var].add(
-            contrib.loc[idx, ["F1", "F2"]], fill_value=0
-        )
+        grouped[var] = grouped[var].add(contrib.loc[idx, ["F1", "F2"]], fill_value=0)
     df = pd.DataFrame(grouped).T.fillna(0)
 
     # Order by total contribution and keep top ``n`` ---------------------
@@ -3293,7 +3307,9 @@ def _factor_method_figures(
         qcoords = pd.DataFrame()
     if not qcoords.empty and "model" in res:
         dest = (
-            out / method.lower() / f"{method}_correlation.png" if out else Path(f"{method}_correlation.png")
+            out / method.lower() / f"{method}_correlation.png"
+            if out
+            else Path(f"{method}_correlation.png")
         )
         corr_path = plot_correlation_circle(
             res["model"], quant_vars, dest, coords=qcoords
@@ -3302,7 +3318,9 @@ def _factor_method_figures(
     inertia = res.get("inertia")
     if isinstance(inertia, pd.Series) and not inertia.empty:
         dest = (
-            out / method.lower() / f"{method}_scree.png" if out else Path(f"{method}_scree.png")
+            out / method.lower() / f"{method}_scree.png"
+            if out
+            else Path(f"{method}_scree.png")
         )
         scree_path = plot_scree(inertia, method.upper(), dest)
         figures[f"{method}_scree"] = scree_path
@@ -3315,8 +3333,8 @@ def _factor_method_figures(
 
     # Combined analysis summary page ------------------------------------
     summary_fig = plot_analysis_summary(
-        corr_path if 'corr_path' in locals() else None,
-        scree_path if 'scree_path' in locals() else None,
+        corr_path if "corr_path" in locals() else None,
+        scree_path if "scree_path" in locals() else None,
         km_eval,
         contrib_fig,
     )
@@ -3389,7 +3407,9 @@ def _nonlin_method_figures(
         figures[f"{method}_cluster_grid"] = grid_fig
         _save(grid_fig, f"{method}_cluster_grid")
         labels = km_labels
-        title = f"Projection {method.upper()} – coloration par clusters (K-Means, k={km_k})"
+        title = (
+            f"Projection {method.upper()} – coloration par clusters (K-Means, k={km_k})"
+        )
         save_name = f"{method}_clusters_kmeans_k{km_k}"
         cfig = plot_cluster_scatter(emb.iloc[:, :2], labels, title)
         figures[save_name] = cfig
@@ -3669,7 +3689,10 @@ def unsupervised_cv_and_temporal_tests(
         umap = None  # type: ignore
 
     if kf is not None:
-        def _process_split(train_idx: np.ndarray, test_idx: np.ndarray) -> tuple[float, float, float, float]:
+
+        def _process_split(
+            train_idx: np.ndarray, test_idx: np.ndarray
+        ) -> tuple[float, float, float, float]:
             df_train = df_active.iloc[train_idx]
             df_test = df_active.iloc[test_idx]
 
@@ -3685,7 +3708,11 @@ def unsupervised_cv_and_temporal_tests(
 
             axis_score = _axis_similarity(pca_train.components_, pca_test.components_)
             dist_score = _distance_discrepancy(emb_proj, emb_test)
-            var_ratio = float(pca_train.explained_variance_ratio_[0]) if pca_train.explained_variance_ratio_.size else float("nan")
+            var_ratio = (
+                float(pca_train.explained_variance_ratio_[0])
+                if pca_train.explained_variance_ratio_.size
+                else float("nan")
+            )
 
             umap_score = float("nan")
             if umap is not None:
@@ -3844,17 +3871,11 @@ def format_metrics_table(df: pd.DataFrame) -> pd.DataFrame:
                 lambda x: f"{int(round(x))}" if pd.notna(x) else ""
             )
         elif col == "nb_axes_kaiser":
-            formatted[col] = series.map(
-                lambda x: f"{int(x)}" if pd.notna(x) else ""
-            )
+            formatted[col] = series.map(lambda x: f"{int(x)}" if pd.notna(x) else "")
         elif pd.api.types.is_integer_dtype(series):
-            formatted[col] = series.map(
-                lambda x: f"{int(x)}" if pd.notna(x) else ""
-            )
+            formatted[col] = series.map(lambda x: f"{int(x)}" if pd.notna(x) else "")
         elif pd.api.types.is_float_dtype(series):
-            formatted[col] = series.map(
-                lambda x: f"{x:.2f}" if pd.notna(x) else ""
-            )
+            formatted[col] = series.map(lambda x: f"{x:.2f}" if pd.notna(x) else "")
         else:
             formatted[col] = series.astype(str).replace("nan", "")
     return formatted


### PR DESCRIPTION
## Summary
- drop metrics table from the PDF generation pipeline
- orient cluster metrics grid horizontally and remove silhouette intervals
- simplify combined silhouette curves

## Testing
- `pytest -q`