### PR TITLE
Limit OPENBLAS threads

### DIFF
--- a/phase4.py
+++ b/phase4.py
@@ -115,15 +115,20 @@ def set_blas_threads(n_jobs: int = -1) -> int:
     """Set thread count for common BLAS libraries."""
     if n_jobs is None or n_jobs < 1:
         n_jobs = os.cpu_count() or 1
+    # OPENBLAS triggers a warning if the requested thread count exceeds the
+    # value it was compiled with.  The bundled build in this repository uses a
+    # limit of 24 threads.  Cap the environment variable accordingly while
+    # leaving the others untouched.
+    openblas_threads = min(n_jobs, 24)
     for var in [
         "OMP_NUM_THREADS",
-        "OPENBLAS_NUM_THREADS",
         "MKL_NUM_THREADS",
         "NUMEXPR_NUM_THREADS",
         "VECLIB_MAXIMUM_THREADS",
         "BLIS_NUM_THREADS",
     ]:
         os.environ[var] = str(n_jobs)
+    os.environ["OPENBLAS_NUM_THREADS"] = str(openblas_threads)
     return n_jobs
 
 

--- a/tests/test_threads.py
+++ b/tests/test_threads.py
@@ -13,3 +13,9 @@ def test_set_blas_threads_sets_env(monkeypatch):
     assert os.environ['OPENBLAS_NUM_THREADS'] == '3'
     assert os.environ['MKL_NUM_THREADS'] == '3'
     assert os.environ['OMP_NUM_THREADS'] == '3'
+
+
+def test_set_blas_threads_caps_openblas(monkeypatch):
+    monkeypatch.delenv('OPENBLAS_NUM_THREADS', raising=False)
+    set_blas_threads(64)
+    assert os.environ['OPENBLAS_NUM_THREADS'] == '24'


### PR DESCRIPTION
## Summary
- cap OPENBLAS thread count in `set_blas_threads`
- test that large n_jobs caps OPENBLAS threads

## Testing
- `pytest -q`