### PR TITLE
Limit BLAS threads

### DIFF
--- a/phase4.py
+++ b/phase4.py
@@ -27,6 +27,11 @@ import json
 import logging
 import os
 
+try:
+    from threadpoolctl import threadpool_limits
+except Exception:  # pragma: no cover - optional dependency
+    threadpool_limits = None
+
 # limite OpenBLAS à 24 threads (ou moins)
 os.environ["OPENBLAS_NUM_THREADS"] = "24"
 from pathlib import Path
@@ -47,6 +52,11 @@ import warnings
 
 warnings.filterwarnings("ignore", category=RuntimeWarning)
 warnings.filterwarnings("ignore", category=FutureWarning)
+warnings.filterwarnings(
+    "ignore",
+    message="Workbook contains no default style, apply openpyxl's default",
+    module="openpyxl",
+)
 
 # Import helper modules -------------------------------------------------------
 from phase4_functions import (
@@ -115,15 +125,23 @@ def set_blas_threads(n_jobs: int = -1) -> int:
     """Set thread count for common BLAS libraries."""
     if n_jobs is None or n_jobs < 1:
         n_jobs = os.cpu_count() or 1
+    # OPENBLAS triggers a warning if the requested thread count exceeds the
+    # value it was compiled with.  The bundled build in this repository uses a
+    # limit of 24 threads.  Cap the environment variable accordingly while
+    # leaving the others untouched.
+    openblas_threads = min(n_jobs, 24)
     for var in [
         "OMP_NUM_THREADS",
-        "OPENBLAS_NUM_THREADS",
         "MKL_NUM_THREADS",
         "NUMEXPR_NUM_THREADS",
         "VECLIB_MAXIMUM_THREADS",
         "BLIS_NUM_THREADS",
     ]:
         os.environ[var] = str(n_jobs)
+    os.environ["OPENBLAS_NUM_THREADS"] = str(openblas_threads)
+    if threadpool_limits is not None:
+        # Also limit threads at runtime for loaded libraries
+        threadpool_limits(openblas_threads)
     return n_jobs
 
 

--- a/tests/test_threads.py
+++ b/tests/test_threads.py
@@ -13,3 +13,20 @@ def test_set_blas_threads_sets_env(monkeypatch):
     assert os.environ['OPENBLAS_NUM_THREADS'] == '3'
     assert os.environ['MKL_NUM_THREADS'] == '3'
     assert os.environ['OMP_NUM_THREADS'] == '3'
+
+
+def test_set_blas_threads_caps_openblas(monkeypatch):
+    monkeypatch.delenv('OPENBLAS_NUM_THREADS', raising=False)
+    set_blas_threads(64)
+    assert os.environ['OPENBLAS_NUM_THREADS'] == '24'
+
+
+def test_set_blas_threads_uses_threadpoolctl(monkeypatch):
+    calls = []
+
+    def fake_limits(n):
+        calls.append(n)
+
+    monkeypatch.setattr('phase4.threadpool_limits', fake_limits)
+    set_blas_threads(8)
+    assert calls == [8]


### PR DESCRIPTION
## Summary
- cap BLAS threads using threadpoolctl when available
- suppress openpyxl style warnings
- verify threadpoolctl usage in tests

## Testing
- `pytest -q`