### PR TITLE
Fix worker cleanup with context-managed joblib

### DIFF
--- a/phase4_functions.py
+++ b/phase4_functions.py
@@ -1740,7 +1740,8 @@ def cluster_evaluation_metrics(
         dunn = dunn_index(X, labels)
         return k, sil_mean, sil_mean - sil_err, sil_mean + sil_err, dunn
 
-    results = Parallel(n_jobs=-1)(delayed(_eval)(k) for k in k_range)
+    with Parallel(n_jobs=-1) as parallel:
+        results = parallel(delayed(_eval)(k) for k in k_range)
 
     records: list[dict[str, float]] = []
     best_k = None
@@ -1839,7 +1840,8 @@ def dbscan_evaluation_metrics(
         dunn = dunn_index(X, labels)
         return eps, sil_mean, sil_mean - sil_err, sil_mean + sil_err, dunn, n_clusters
 
-    results = Parallel(n_jobs=-1)(delayed(_eval)(e) for e in eps_values)
+    with Parallel(n_jobs=-1) as parallel:
+        results = parallel(delayed(_eval)(e) for e in eps_values)
 
     records: list[dict[str, float]] = []
     best_eps = None
@@ -1964,9 +1966,12 @@ def hdbscan_evaluation_metrics(
         dunn = dunn_index(X, labels)
         return mcs, ms, sil_mean, sil_mean - sil_err, sil_mean + sil_err, dunn
 
-    results = Parallel(n_jobs=-1)(
-        delayed(_eval)(mcs, ms) for mcs in mcs_values for ms in min_samples_values
-    )
+    with Parallel(n_jobs=-1) as parallel:
+        results = parallel(
+            delayed(_eval)(mcs, ms)
+            for mcs in mcs_values
+            for ms in min_samples_values
+        )
 
     records: list[dict[str, float]] = []
     best: tuple[int, int] | None = None
@@ -2270,9 +2275,9 @@ def evaluate_methods(
         }
         return method, labels, row
 
-    parallel_res = Parallel(n_jobs=-1)(
-        delayed(_process)(it) for it in results_dict.items()
-    )
+    with Parallel(n_jobs=-1) as parallel:
+        parallel_res = parallel(delayed(_process)(it) for it in results_dict.items())
+
     rows = []
     for method, labels, row in parallel_res:
         results_dict[method]["cluster_labels"] = labels
@@ -3546,8 +3551,9 @@ def generate_figures(
         )
 
     n_jobs = n_jobs if n_jobs is not None else -1
-    for res_dict in Parallel(n_jobs=n_jobs, backend=backend)(tasks):
-        figures.update(res_dict)
+    with Parallel(n_jobs=n_jobs, backend=backend) as parallel:
+        for res_dict in parallel(tasks):
+            figures.update(res_dict)
 
     return figures
 
@@ -3725,9 +3731,10 @@ def unsupervised_cv_and_temporal_tests(
 
             return axis_score, dist_score, var_ratio, umap_score
 
-        results = Parallel(n_jobs=-1)(
-            delayed(_process_split)(tr, te) for tr, te in kf.split(df_active)
-        )
+        with Parallel(n_jobs=-1) as parallel:
+            results = parallel(
+                delayed(_process_split)(tr, te) for tr, te in kf.split(df_active)
+            )
         for axis, dist, var, um in results:
             pca_axis_scores.append(axis)
             pca_dist_scores.append(dist)

--- a/phase4_parallel.py
+++ b/phase4_parallel.py
@@ -32,7 +32,8 @@ def run_pipeline_parallel(
     """Run :func:`phase4.run_pipeline` on several datasets in parallel."""
 
     n_jobs = n_jobs or len(datasets)
-    results = Parallel(n_jobs=n_jobs, backend=backend)(
-        delayed(_run_pipeline_single)(config, ds) for ds in datasets
-    )
+    with Parallel(n_jobs=n_jobs, backend=backend) as parallel:
+        results = parallel(
+            delayed(_run_pipeline_single)(config, ds) for ds in datasets
+        )
     return dict(results)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -60,6 +60,12 @@ def test_run_pipeline_parallel_calls(monkeypatch, tmp_path):
         def __call__(self, tasks):
             return [task() for task in tasks]
 
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
     def fake_delayed(func):
         def wrapper(*args, **kwargs):
             return lambda: func(*args, **kwargs)
@@ -101,6 +107,12 @@ def test_run_pipeline_parallel_concats_reports(monkeypatch, tmp_path):
 
         def __call__(self, tasks):
             return [task() for task in tasks]
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
 
     def fake_delayed(func):
         def wrapper(*args, **kwargs):


### PR DESCRIPTION
## Summary
- run joblib `Parallel` within a context manager so workers close correctly
- mirror the change in helper module `phase4_parallel`
- update helper functions in `phase4_functions` to use context managed parallelism
- adapt tests with context-manager compatible fake parallel classes

## Testing
- `pytest -q`