### PR TITLE
Fix logging handlers to avoid hanging

### DIFF
--- a/phase4.py
+++ b/phase4.py
@@ -81,6 +81,13 @@ def _setup_logging(output_dir: Path, level: str = "INFO") -> logging.Logger:
     output_dir.mkdir(parents=True, exist_ok=True)
     logger = logging.getLogger()
     logger.setLevel(level)
+    # Remove existing handlers to avoid duplicate log lines when running the
+    # pipeline multiple times within the same process.
+    for h in list(logger.handlers):
+        logger.removeHandler(h)
+        with suppress(Exception):
+            h.close()
+
     fmt = logging.Formatter("%(asctime)s [%(levelname)s] %(message)s")
     file_handler = logging.FileHandler(output_dir / "phase4.log", encoding="utf-8")
     file_handler.setFormatter(fmt)
@@ -606,7 +613,16 @@ def build_type_report(base_dir: Path, pdf_path: Path, datasets: Sequence[str]) -
                     continue
                 _grid_page(pdf, imgs, f"{title} – {ds}")
 
-        if any(v for v in annex_images.values()):
+        extra_imgs = []
+        gen_heatmap = base_dir / "general_heatmap.png"
+        if gen_heatmap.exists():
+            extra_imgs.append((gen_heatmap, "Synthèse générale"))
+
+        miss_fig = base_dir / datasets[0] / "segment_summary_2.png"
+        if miss_fig.exists():
+            extra_imgs.append((miss_fig, "% NA par segment"))
+
+        if any(v for v in annex_images.values()) or extra_imgs:
             fig, ax = plt.subplots(figsize=page_size, dpi=200)
             ax.axis("off")
             ax.text(
@@ -614,6 +630,9 @@ def build_type_report(base_dir: Path, pdf_path: Path, datasets: Sequence[str]) -
             )
             pdf.savefig(fig)
             plt.close(fig)
+
+            for img, title in extra_imgs:
+                _grid_page(pdf, [img], title)
 
             if annex_images["segments"]:
                 _grid_page(pdf, annex_images["segments"], "Segments")
@@ -757,6 +776,69 @@ def concat_pdf_reports(output_dir: Path, output_pdf: Path) -> Path:
             os.remove(tmp_gen)
 
     return output_pdf
+
+
+def save_segment_analysis_figures(df: pd.DataFrame, output_dir: Path) -> None:
+    """Generate and save segment summary figures used in the final report."""
+
+    seg_cols1 = [
+        "Catégorie",
+        "Sous-catégorie",
+        "Entité opérationnelle",
+        "Statut commercial",
+    ]
+    seg_cols2 = ["Pilier", "Statut production", "Type opportunité"]
+    all_cols = seg_cols1 + seg_cols2
+
+    def _plot(ax: plt.Axes, series: pd.Series, name: str) -> None:
+        counts = series.astype(str).value_counts(dropna=False)
+        ax.bar(counts.index.astype(str), counts.values, edgecolor="black")
+        ax.set_xlabel(name)
+        ax.set_ylabel("Effectif")
+        for label in ax.get_xticklabels():
+            label.set_rotation(45)
+            label.set_ha("right")
+
+    fig1, axes1 = plt.subplots(2, 2, figsize=(11.69, 8.27), dpi=200)
+    for ax, col in zip(axes1.ravel(), seg_cols1):
+        if col in df.columns:
+            _plot(ax, df[col], col)
+        else:
+            ax.axis("off")
+            ax.text(0.5, 0.5, "Données manquantes", ha="center", va="center", fontsize=8)
+    fig1.tight_layout()
+    path1 = output_dir / "segment_summary_1.png"
+    fig1.savefig(path1)
+    plt.close(fig1)
+
+    fig2, axes2 = plt.subplots(2, 2, figsize=(11.69, 8.27), dpi=200)
+    for ax, col in zip(axes2.ravel()[:3], seg_cols2):
+        if col in df.columns:
+            _plot(ax, df[col], col)
+        else:
+            ax.axis("off")
+            ax.text(0.5, 0.5, "Données manquantes", ha="center", va="center", fontsize=8)
+
+    ax = axes2.ravel()[3]
+    avail = [c for c in all_cols if c in df.columns]
+    if avail:
+        pct = df[avail].isna().mean().mul(100)
+        ax.bar(pct.index.astype(str), pct.values, edgecolor="black")
+        ax.set_ylabel("% NA")
+        for label in ax.get_xticklabels():
+            label.set_rotation(45)
+            label.set_ha("right")
+        ax.set_xlabel("Segment")
+    else:
+        ax.axis("off")
+        ax.text(0.5, 0.5, "Données manquantes", ha="center", va="center", fontsize=8)
+
+    fig2.tight_layout()
+    path2 = output_dir / "segment_summary_2.png"
+    fig2.savefig(path2)
+    plt.close(fig2)
+
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -968,23 +1050,11 @@ def run_pipeline(config: Dict[str, Any]) -> Dict[str, Any]:
         )
         pd.DataFrame(robustness_df).to_csv(output_dir / "robustness.csv")
 
-    if config.get("output_pdf"):
-        logging.info("Building PDF report...")
-        tables: Dict[str, pd.DataFrame] = {}
-        if comparison_metrics is not None:
-            tables["comparison_metrics"] = format_metrics_table(comparison_metrics)
-        if robustness_df is not None:
-            tables["robustness"] = pd.DataFrame(robustness_df)
-        dataset_order = [data_key] + comparison_names
-        build_pdf_report(
-            output_dir,
-            Path(config["output_pdf"]),
-            dataset_order,
-            tables,
-            df_active,
-        )
+    # Save segment summary figures for later report assembly
+    save_segment_analysis_figures(df_active, output_dir)
 
     logging.info("Analysis complete")
+    logging.shutdown()
     return {
         "metrics": metrics,
         "figures": figures,
@@ -1042,9 +1112,9 @@ def run_pipeline_parallel(
     if "output_pdf" in config:
         base_dir = Path(config.get("output_dir", "phase4_output"))
         pdf = Path(config["output_pdf"])
-        combined = pdf.with_name(f"{pdf.stem}_combined{pdf.suffix}")
-        concat_pdf_reports(base_dir, combined)
+        build_type_report(base_dir, pdf, datasets)
 
+    logging.shutdown()
     return results
 
 

--- a/phase4_parallel.py
+++ b/phase4_parallel.py
@@ -16,9 +16,8 @@ def _run_pipeline_single(config: Dict[str, Any], name: str) -> tuple[str, Dict[s
     if "output_dir" in cfg:
         base = Path(cfg["output_dir"])
         cfg["output_dir"] = str(base / name)
-    if "output_pdf" in cfg:
-        pdf = Path(cfg["output_pdf"])
-        cfg["output_pdf"] = str(pdf.with_name(f"{pdf.stem}_{name}{pdf.suffix}"))
+    # intermediate PDFs are no longer generated
+    cfg.pop("output_pdf", None)
     return name, phase4.run_pipeline(cfg)
 
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -39,6 +39,7 @@ def test_run_pipeline_respects_optimize(tmp_path, monkeypatch):
     monkeypatch.setattr(phase4, "evaluate_methods", lambda *a, **k: pd.DataFrame())
     monkeypatch.setattr(phase4, "plot_methods_heatmap", lambda *a, **k: None)
     monkeypatch.setattr(phase4, "generate_figures", lambda *a, **k: {})
+    monkeypatch.setattr(phase4, "save_segment_analysis_figures", lambda *a, **k: None)
     phase4.run_pipeline(cfg)
 
     assert called.get("optimize") is False
@@ -84,15 +85,11 @@ def test_run_pipeline_parallel_calls(monkeypatch, tmp_path):
     assert calls["backend"] == "multiprocessing"
 
 
-def test_run_pipeline_parallel_concats_reports(monkeypatch, tmp_path):
-    created = []
-    concat_calls = {}
+def test_run_pipeline_parallel_builds_report(monkeypatch, tmp_path):
+    build_calls = {}
 
     def fake_run_pipeline(cfg):
-        path = Path(cfg["output_pdf"])
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text("pdf")
-        created.append(path.name)
+        Path(cfg["output_dir"]).mkdir(parents=True, exist_ok=True)
         return {}
 
     class FakeParallel:
@@ -107,15 +104,15 @@ def test_run_pipeline_parallel_concats_reports(monkeypatch, tmp_path):
             return lambda: func(*args, **kwargs)
         return wrapper
 
-    def fake_concat(out_dir, pdf_path):
-        concat_calls["args"] = (out_dir, pdf_path)
+    def fake_build(out_dir, pdf_path, datasets):
+        build_calls["args"] = (out_dir, pdf_path, datasets)
         pdf_path.parent.mkdir(parents=True, exist_ok=True)
-        pdf_path.write_text("combined")
+        pdf_path.write_text("final")
         return pdf_path
 
     monkeypatch.setattr(phase4, "run_pipeline", fake_run_pipeline)
     monkeypatch.setattr(phase4, "plot_general_heatmap", lambda *a, **k: None)
-    monkeypatch.setattr(phase4, "concat_pdf_reports", fake_concat)
+    monkeypatch.setattr(phase4, "build_type_report", fake_build)
     monkeypatch.setattr(phase4, "Parallel", FakeParallel)
     monkeypatch.setattr(phase4, "delayed", fake_delayed)
 
@@ -128,6 +125,9 @@ def test_run_pipeline_parallel_concats_reports(monkeypatch, tmp_path):
 
     phase4.run_pipeline_parallel(cfg, datasets)
 
-    expected_final = Path(cfg["output_pdf"]).with_name("phase4_report_combined.pdf")
-    assert concat_calls["args"] == (Path(cfg["output_dir"]), expected_final)
+    assert build_calls["args"] == (
+        Path(cfg["output_dir"]),
+        Path(cfg["output_pdf"]),
+        datasets,
+    )
     


### PR DESCRIPTION
## Summary
- avoid duplicate log handlers by clearing existing ones in `_setup_logging`
- call `logging.shutdown()` at the end of `run_pipeline` and `run_pipeline_parallel`
- stop generating intermediate PDFs and save only a final combined report
- save segment analysis figures for later use
- update tests for new report generation

## Testing
- `pytest -q`
