### PR TITLE
Fix dataset parallelization hang

### DIFF
--- a/phase4.py
+++ b/phase4.py
@@ -1099,7 +1099,11 @@ def _run_pipeline_single(
     if "output_pdf" in cfg:
         pdf = Path(cfg["output_pdf"])
         cfg["output_pdf"] = str(pdf.with_name(f"{pdf.stem}_{name}{pdf.suffix}"))
-    return name, run_pipeline(cfg)
+    result = run_pipeline(cfg)
+    # Avoid pickling large matplotlib objects in parallel mode
+    if isinstance(result, dict) and "figures" in result:
+        result.pop("figures", None)
+    return name, result
 
 
 def run_pipeline_parallel(

--- a/phase4_parallel.py
+++ b/phase4_parallel.py
@@ -18,7 +18,11 @@ def _run_pipeline_single(config: Dict[str, Any], name: str) -> tuple[str, Dict[s
         cfg["output_dir"] = str(base / name)
     # intermediate PDFs are no longer generated
     cfg.pop("output_pdf", None)
-    return name, phase4.run_pipeline(cfg)
+    result = phase4.run_pipeline(cfg)
+    # Drop heavy figure objects to avoid pickling overhead
+    if isinstance(result, dict) and "figures" in result:
+        result.pop("figures", None)
+    return name, result
 
 
 def run_pipeline_parallel(


### PR DESCRIPTION
## Summary
- skip returning heavy figures from individual dataset runs to avoid large pickles

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*