### PR TITLE
Remove text labels from correlation circle arrows

### DIFF
--- a/old/phase4v3.py
+++ b/old/phase4v3.py
@@ -783,7 +783,6 @@ def plot_correlation_circle(coords: pd.DataFrame, title: str) -> plt.Figure:
     norms = np.sqrt(np.square(coords["F1"]) + np.square(coords["F2"]))
     palette = sns.color_palette("husl", len(coords))
     handles: list[Line2D] = []
-    offset = 0.05
     for var, color, norm in zip(coords.index, palette, norms):
         x, y = coords.loc[var, ["F1", "F2"]]
         alpha = 0.3 + 0.7 * norm
@@ -798,14 +797,6 @@ def plot_correlation_circle(coords: pd.DataFrame, title: str) -> plt.Figure:
             linewidth=0.8,
             color=color,
             alpha=alpha,
-        )
-        ax.text(
-            x + (offset if x >= 0 else -offset),
-            y + (offset if y >= 0 else -offset),
-            str(var),
-            fontsize=8,
-            ha="left" if x >= 0 else "right",
-            va="bottom" if y >= 0 else "top",
         )
         handles.append(Line2D([0], [0], color=color, lw=1.0, label=str(var)))
 

--- a/old/visualization.py
+++ b/old/visualization.py
@@ -36,7 +36,6 @@ def plot_correlation_circle(coords: pd.DataFrame, title: str) -> plt.Figure:
     norms = np.sqrt(np.square(coords["F1"]) + np.square(coords["F2"]))
     palette = sns.color_palette("husl", len(coords))
     handles: list[Line2D] = []
-    offset = 0.05
     for var, color, norm in zip(coords.index, palette, norms):
         x, y = coords.loc[var, ["F1", "F2"]]
         alpha = 0.3 + 0.7 * norm
@@ -51,14 +50,6 @@ def plot_correlation_circle(coords: pd.DataFrame, title: str) -> plt.Figure:
             linewidth=0.8,
             color=color,
             alpha=alpha,
-        )
-        ax.text(
-            x + (offset if x >= 0 else -offset),
-            y + (offset if y >= 0 else -offset),
-            str(var),
-            fontsize=8,
-            ha="left" if x >= 0 else "right",
-            va="bottom" if y >= 0 else "top",
         )
         handles.append(Line2D([0], [0], color=color, lw=1.0, label=str(var)))
 

--- a/phase4_functions.py
+++ b/phase4_functions.py
@@ -2493,7 +2493,6 @@ def plot_correlation_circle(
     ax.axhline(0, color="grey", lw=0.5)
     ax.axvline(0, color="grey", lw=0.5)
 
-    offset = 0.05 * scale
     palette = sns.color_palette("husl", len(coords))
     handles: list[Line2D] = []
     for var, color, norm in zip(coords.index, palette, norms):
@@ -2510,14 +2509,6 @@ def plot_correlation_circle(
             linewidth=0.8,
             color=color,
             alpha=alpha,
-        )
-        ax.text(
-            x + (offset if x >= 0 else -offset),
-            y + (offset if y >= 0 else -offset),
-            str(var),
-            fontsize=8,
-            ha="left" if x >= 0 else "right",
-            va="bottom" if y >= 0 else "top",
         )
         handles.append(Line2D([0], [0], color=color, lw=1.0, label=str(var)))
 


### PR DESCRIPTION
## Notes
- Removed annotations from arrows in correlation circle plots while keeping the legend.
- Adjusted all versions of the plotting function in the repository.

## Summary
- Stopped creating text labels in `plot_correlation_circle` and legend only remains
- Did the same for old helper modules

All tests pass:
```
46 passed, 51 warnings in 136.52s (0:02:16)
```
