### PR TITLE
Fix PDF generation and remove cluster legends

### DIFF
--- a/RapportAnalyse.py
+++ b/RapportAnalyse.py
@@ -1,6 +1,7 @@
 import yaml
 from pathlib import Path
 import phase4_functions as pf
+from phase4 import build_pdf_report
 
 
 def main():
@@ -8,7 +9,7 @@ def main():
         config = yaml.safe_load(fh)
     datasets = pf.load_datasets(config, ignore_schema=True)
     result = pf.compare_datasets_versions(datasets, output_dir=Path("rapport_output"))
-    pf.build_pdf_report(Path("rapport_output"), Path("RapportAnalyse.pdf"), list(datasets))
+    build_pdf_report(Path("rapport_output"), Path("RapportAnalyse.pdf"), list(datasets))
 
 
 if __name__ == "__main__":

--- a/phase4_functions.py
+++ b/phase4_functions.py
@@ -2744,9 +2744,6 @@ def plot_cluster_scatter_3d(
             color="black",
             zorder=3,
         )
-    handles, labels = ax.get_legend_handles_labels()
-    if labels:
-        ax.legend(title="cluster", bbox_to_anchor=(1.05, 1), loc="upper left")
     ax.set_xlabel(emb_df.columns[0])
     ax.set_ylabel(emb_df.columns[1])
     ax.set_zlabel(emb_df.columns[2])
@@ -2801,9 +2798,6 @@ def plot_cluster_scatter(
             color="black",
             zorder=3,
         )
-    handles, labels = ax.get_legend_handles_labels()
-    if labels:
-        ax.legend(title="cluster", bbox_to_anchor=(1.05, 1), loc="upper left")
     ax.set_xlabel(emb_df.columns[0])
     ax.set_ylabel(emb_df.columns[1])
     ax.set_title(title)
@@ -2873,10 +2867,7 @@ def plot_cluster_grid(
         f"{method.upper()} \u2013 Gaussian Mixture (k={gmm_k})",
     )
 
-    for ax in axes:
-        handles, labels = ax.get_legend_handles_labels()
-        if labels:
-            ax.legend(title="cluster", bbox_to_anchor=(1.05, 1), loc="upper left")
+
 
     fig.tight_layout()
     return fig


### PR DESCRIPTION
## Summary
- call build_pdf_report from the correct module in `RapportAnalyse.py`
- drop cluster color legends from cluster scatter plots

## Testing
- `pytest -q`