### PR TITLE
Refactor PDF report generation

### DIFF
--- a/RapportAnalyse.py
+++ b/RapportAnalyse.py
@@ -7,8 +7,16 @@ def main():
     with open("config.yaml", "r", encoding="utf-8") as fh:
         config = yaml.safe_load(fh)
     datasets = pf.load_datasets(config, ignore_schema=True)
-    result = pf.compare_datasets_versions(datasets, output_dir=Path("rapport_output"))
-    pf.build_pdf_report(Path("rapport_output"), Path("RapportAnalyse.pdf"), list(datasets))
+    results = pf.compare_datasets_versions(datasets)
+
+    figures = {}
+    for ds_name, det in results["details"].items():
+        for name, fig in det.get("figures", {}).items():
+            figures[f"{ds_name}_{name}"] = fig
+
+    tables = {"metrics": results["metrics"]}
+    output_pdf = Path(config.get("output_pdf", "RapportAnalyse.pdf"))
+    pf.export_report_to_pdf(figures, tables, output_pdf)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- restructure `export_report_to_pdf` to create 3 pages per dataset and method
- keep remaining figures after the structured pages
- strip cluster legends and fix `RapportAnalyse` script

## Testing
- `flake8` *(fails: tests have lint issues)*
- `pytest -q tests/test_factor_methods.py::test_run_mfa_basic`
