### PR TITLE
Fix clustering hint parameters

### DIFF
--- a/phase4.py
+++ b/phase4.py
@@ -131,6 +131,8 @@ def _method_params(method: str, config: Mapping[str, Any]) -> Dict[str, Any]:
     for key, value in config.items():
         if key.startswith(prefix) and value is not None:
             params[key[len(prefix) :]] = value
+    # Filter out clustering hints like ``k_raw`` that are not method arguments
+    params = {k: v for k, v in params.items() if not str(k).startswith("k_")}
     return params
 
 


### PR DESCRIPTION
## Summary
- filter out keys starting with `k_` from method configs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a258bbba88332b1ae6167378d480e