### PR TITLE
Add clustering metrics to heatmaps

### DIFF
--- a/phase4_functions.py
+++ b/phase4_functions.py
@@ -2228,9 +2228,14 @@ def evaluate_methods(
         if len(labels) <= best_k or len(set(labels)) < 2:
             sil = float("nan")
             dunn = float("nan")
+            ch = float("nan")
+            inv_db = float("nan")
         else:
             sil = float(silhouette_score(X_low, labels))
             dunn = dunn_index(X_low, labels)
+            ch = float(calinski_harabasz_score(X_low, labels))
+            db = davies_bouldin_score(X_low, labels)
+            inv_db = 1.0 / db if db > 0 else float("nan")
 
         try:
             enc = OneHotEncoder(sparse_output=False, handle_unknown="ignore")
@@ -2263,6 +2268,8 @@ def evaluate_methods(
             "nb_axes_kaiser": kaiser,
             "silhouette": sil,
             "dunn_index": dunn,
+            "calinski_harabasz": ch,
+            "inv_davies_bouldin": inv_db,
             "trustworthiness": T,
             "continuity": C,
             "runtime_seconds": runtime,

--- a/tests/test_evaluate_methods.py
+++ b/tests/test_evaluate_methods.py
@@ -51,6 +51,8 @@ def test_evaluate_and_plot(tmp_path, monkeypatch):
         "nb_axes_kaiser",
         "silhouette",
         "dunn_index",
+        "calinski_harabasz",
+        "inv_davies_bouldin",
         "trustworthiness",
         "continuity",
         "runtime_seconds",


### PR DESCRIPTION
## Summary
- include Calinski-Harabasz and inverse Davies–Bouldin scores when evaluating methods
- expose those metrics in the evaluation heatmaps
- update unit tests

## Testing
- `pytest tests/test_evaluate_methods.py::test_evaluate_and_plot -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a4fbaed1883328de2f5934f033b6b