### PR TITLE
Add segment NA figure to Phase 4 reports

### DIFF
--- a/generate_phase4_report.py
+++ b/generate_phase4_report.py
@@ -200,6 +200,11 @@ def export_report_to_pdf(
         used_keys.add(key)
 
     remaining = {k: v for k, v in figures.items() if k not in used_keys}
+    segment_figs = {
+        k: v for k, v in remaining.items() if "segment_summary_2" in k
+    }
+    for k in segment_figs:
+        del remaining[k]
 
     try:
         from fpdf import FPDF  # type: ignore
@@ -245,6 +250,14 @@ def export_report_to_pdf(
                         pdf.add_page()
                         _add_title(f"{dataset} – {method.upper()} – {label}")
                         pdf.image(img, w=180)
+
+        for name, fig in segment_figs.items():
+            img = _fig_to_path(fig, tmp_paths)
+            if img:
+                pdf.add_page()
+                ds = name.rsplit("_segment_summary_2", 1)[0]
+                _add_title(f"% NA par segment – {ds}")
+                pdf.image(img, w=180)
 
         for name, fig in remaining.items():
             img = _fig_to_path(fig, tmp_paths)
@@ -308,6 +321,10 @@ def export_report_to_pdf(
                     ]
                     for fig, label in pages:
                         _save_page(f"{dataset} – {method.upper()} – {label}", fig)
+
+            for name, fig in segment_figs.items():
+                ds = name.rsplit("_segment_summary_2", 1)[0]
+                _save_page(f"% NA par segment – {ds}", fig)
 
             for name, fig in remaining.items():
                 _save_page(name, fig)

--- a/phase4.py
+++ b/phase4.py
@@ -1130,6 +1130,12 @@ def run_pipeline(config: Dict[str, Any]) -> Dict[str, Any]:
 
     # Save segment summary figures for later report assembly
     save_segment_analysis_figures(df_active, output_dir)
+    seg1_path = output_dir / "segment_summary_1.png"
+    seg2_path = output_dir / "segment_summary_2.png"
+    if seg1_path.exists():
+        figures["segment_summary_1"] = seg1_path
+    if seg2_path.exists():
+        figures["segment_summary_2"] = seg2_path
 
     logging.info("Analysis complete")
     logging.shutdown()

--- a/phase4_functions.py
+++ b/phase4_functions.py
@@ -4176,6 +4176,11 @@ def export_report_to_pdf(
         used_keys.add(key)
 
     remaining = {k: v for k, v in figures.items() if k not in used_keys}
+    segment_figs = {
+        k: v for k, v in remaining.items() if "segment_summary_2" in k
+    }
+    for k in segment_figs:
+        del remaining[k]
 
     try:
         from fpdf import FPDF  # type: ignore
@@ -4222,6 +4227,14 @@ def export_report_to_pdf(
                         pdf.add_page()
                         _add_title(f"{dataset} – {method.upper()} – {label}")
                         pdf.image(img, w=180)
+
+        for name, fig in segment_figs.items():
+            img = _fig_to_path(fig, tmp_paths)
+            if img:
+                pdf.add_page()
+                ds = name.rsplit("_segment_summary_2", 1)[0]
+                _add_title(f"% NA par segment – {ds}")
+                pdf.image(img, w=180)
 
         for name, fig in remaining.items():
             img = _fig_to_path(fig, tmp_paths)
@@ -4285,6 +4298,10 @@ def export_report_to_pdf(
                     ]
                     for fig, label in pages:
                         _save_page(f"{dataset} – {method.upper()} – {label}", fig)
+
+            for name, fig in segment_figs.items():
+                ds = name.rsplit("_segment_summary_2", 1)[0]
+                _save_page(f"% NA par segment – {ds}", fig)
 
             for name, fig in remaining.items():
                 _save_page(name, fig)


### PR DESCRIPTION
## Summary
- include segment summary graphics in returned figure mapping
- detect and group segment summary in both PDF generators
- insert a page for the `% NA par segment` figure when building reports

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ab7999ee88332bdd29144a6cdae48