### PR TITLE
Add PCA contributions export

### DIFF
--- a/generate_phase4_csv.py
+++ b/generate_phase4_csv.py
@@ -34,6 +34,8 @@ from phase4_functions import (
     run_phate,
     run_pacmap,
     evaluate_methods,
+    pca_variable_contributions,
+    pca_individual_contributions,
 )
 
 # ---------------------------------------------------------------------------
@@ -227,6 +229,22 @@ def run(config: Mapping[str, Any]) -> None:
     dist_df = pd.DataFrame(records).set_index("method")
     dist_df.to_csv(output_dir / "cluster_distance_metrics.csv")
     logging.info("Saved cluster distance metrics")
+
+    # PCA contributions ----------------------------------------------------
+    pca_res = factor_results.get("pca")
+    if pca_res:
+        loads = pca_res.get("loadings")
+        emb = pca_res.get("embeddings")
+        if isinstance(loads, pd.DataFrame):
+            contrib = pca_variable_contributions(loads)
+            cols = [c for c in ["F1", "F2"] if c in contrib.columns]
+            contrib[cols].to_csv(output_dir / "ACP_contributions_variables.csv")
+            logging.info("Saved PCA variable contributions")
+        if isinstance(emb, pd.DataFrame):
+            ic = pca_individual_contributions(emb)
+            cols = [c for c in ["F1", "F2"] if c in ic.columns]
+            ic[cols].to_csv(output_dir / "ACP_contributions_individus.csv")
+            logging.info("Saved PCA individual contributions")
 
     # Method parameters -----------------------------------------------------
     params = {m: method_params(m, config) for m in methods}

--- a/phase4_functions.py
+++ b/phase4_functions.py
@@ -860,6 +860,18 @@ def run_pca(
     result["runtime"] = runtime
     return result
 
+def pca_variable_contributions(loadings: pd.DataFrame) -> pd.DataFrame:
+    """Return variable contributions (%) for each PCA axis."""
+    loads_sq = loadings ** 2
+    return loads_sq.div(loads_sq.sum(axis=0), axis=1) * 100
+
+
+def pca_individual_contributions(embeddings: pd.DataFrame) -> pd.DataFrame:
+    """Return individual cos² (%) for each PCA axis."""
+    coords_sq = embeddings ** 2
+    total = coords_sq.sum(axis=1)
+    return coords_sq.div(total, axis=0) * 100
+
 
 def run_mca(
     df_active: pd.DataFrame,

--- a/tests/test_factor_methods.py
+++ b/tests/test_factor_methods.py
@@ -51,3 +51,13 @@ def test_run_mfa_with_weights():
     groups = {"Num": ["num1", "num2"], "Cat": ["cat1", "cat2"]}
     res = pf.run_mfa(df, groups, optimize=True, weights={"Num": 2.0, "Cat": 1.0})
     assert res["embeddings"].shape[0] == len(df)
+
+
+def test_pca_contributions():
+    df = sample_df()
+    res = pf.run_pca(df, ["num1", "num2"], n_components=2)
+    var_contrib = pf.pca_variable_contributions(res["loadings"])
+    assert np.allclose(var_contrib[["F1", "F2"]].sum().values, [100.0, 100.0])
+    ind_contrib = pf.pca_individual_contributions(res["embeddings"])
+    total = ind_contrib.sum(axis=1, skipna=False).dropna()
+    assert np.allclose(total.values, 100.0)


### PR DESCRIPTION
## Summary
- add helpers to compute PCA variable and individual contributions
- export PCA contributions to CSV in `generate_phase4_csv.py`
- test the new contribution helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c631745008332b49f1b93af08882f