### PR TITLE
Add FAMD score export script

### DIFF
--- a/export_famd_scores.py
+++ b/export_famd_scores.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Export FAMD individual factor scores to a CSV file."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from pathlib import Path
+from typing import Any, Mapping
+
+import pandas as pd
+import yaml
+
+import phase4
+from phase4_functions import (
+    load_datasets,
+    prepare_data,
+    select_variables,
+    handle_missing_values,
+    run_famd,
+)
+
+
+def load_config(path: Path) -> Mapping[str, Any]:
+    """Load YAML or JSON configuration file."""
+    with open(path, "r", encoding="utf-8") as fh:
+        if path.suffix.lower() in {".yaml", ".yml"}:
+            return yaml.safe_load(fh)
+        return json.load(fh)
+
+
+def export_famd_scores(
+    config: Mapping[str, Any],
+    *,
+    dataset: str | None = None,
+    output: str | Path = "FAMD_coordonnees_individus.csv",
+) -> pd.DataFrame:
+    """Compute FAMD coordinates and save them to ``output``.
+
+    Parameters
+    ----------
+    config:
+        Configuration mapping used to load the dataset and parameters.
+    dataset:
+        Optional dataset name overriding the value from ``config``.
+    output:
+        Path of the CSV file written by the function.
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame of individual coordinates (index named ``ID``).
+    """
+    datasets = load_datasets(config, ignore_schema=bool(config.get("ignore_schema", False)))
+    name = dataset or config.get("dataset", config.get("main_dataset", "raw"))
+    if name not in datasets:
+        raise KeyError(f"dataset '{name}' not found")
+
+    df_prep = prepare_data(datasets[name], exclude_lost=bool(config.get("exclude_lost", True)))
+    df_active, quant_vars, qual_vars = select_variables(
+        df_prep, min_modalite_freq=int(config.get("min_modalite_freq", 5))
+    )
+    df_active = handle_missing_values(df_active, quant_vars, qual_vars)
+
+    if not quant_vars or not qual_vars:
+        raise ValueError("FAMD requires at least one quantitative and one qualitative variable")
+
+    params = phase4._method_params("famd", config)  # type: ignore[attr-defined]
+    res = run_famd(df_active, quant_vars, qual_vars, optimize=False, **params)
+    coords = res["embeddings"].copy()
+    coords.index.name = "ID"
+    coords.columns = [f"Dim{i+1}_FAMD" for i in range(coords.shape[1])]
+    coords.reset_index().to_csv(output, index=False)
+    return coords
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Export FAMD factor scores")
+    parser.add_argument("--config", default="config.yaml", help="Path to config file")
+    parser.add_argument("--dataset", help="Dataset to process (override config)")
+    parser.add_argument(
+        "--output",
+        default="FAMD_coordonnees_individus.csv",
+        help="Output CSV file",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(format="%(message)s", level=logging.INFO)
+
+    cfg = load_config(Path(args.config))
+    if args.dataset:
+        cfg["dataset"] = args.dataset
+
+    df = export_famd_scores(cfg, dataset=args.dataset, output=args.output)
+    logging.info("Saved %s with %d rows", args.output, len(df))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_export_famd_scores.py
+++ b/tests/test_export_famd_scores.py
@@ -1,0 +1,32 @@
+import pandas as pd
+from pathlib import Path
+from export_famd_scores import export_famd_scores
+
+
+def test_export_famd_scores(tmp_path: Path):
+    df = pd.DataFrame({
+        "Code": [1, 2, 3],
+        "Date de début actualisée": ["2024-01-01", "2024-01-02", "2024-01-03"],
+        "Date de fin réelle": ["2024-01-02", "2024-01-03", "2024-01-04"],
+        "Total recette réalisé": [10, 20, 30],
+        "Budget client estimé": [12, 22, 32],
+        "Categorie": ["A", "B", "A"],
+        "Statut commercial": ["Gagné", "Gagné", "Gagné"],
+    })
+    csv_path = tmp_path / "raw.csv"
+    df.to_csv(csv_path, index=False)
+
+    cfg = {
+        "input_file": str(csv_path),
+        "dataset": "raw",
+        "min_modalite_freq": 1,
+        "famd": {"n_components": 3},
+    }
+    out = tmp_path / "coords.csv"
+
+    coords = export_famd_scores(cfg, output=out)
+    assert out.exists()
+    loaded = pd.read_csv(out)
+    assert list(loaded.columns)[0] == "ID"
+    assert "Dim1_FAMD" in loaded.columns
+    assert len(loaded) == len(coords) == len(df)


### PR DESCRIPTION
## Summary
- add `export_famd_scores.py` to compute FAMD coordinates and save them to CSV
- test the new export function

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c633b1ab88332bcc44c2b51f15514