### PR TITLE
Add silhouette diagram plotting utility

### DIFF
--- a/phase4_functions.py
+++ b/phase4_functions.py
@@ -3065,6 +3065,54 @@ def plot_cluster_segment_heatmap(table: pd.DataFrame, title: str) -> plt.Figure:
     return fig
 
 
+def plot_silhouette_diagram(
+    X: np.ndarray | pd.DataFrame,
+    labels: Sequence[int] | np.ndarray,
+    output_path: str | Path,
+) -> Path:
+    """Save a silhouette diagram for ``labels`` computed on ``X``.
+
+    Each cluster is represented by a horizontal bar showing individual
+    silhouette scores sorted from largest to smallest.  A dashed line marks
+    the overall mean silhouette.
+    """
+
+    scores = silhouette_samples_safe(np.asarray(X), np.asarray(labels))
+    mean_score = float(np.nanmean(scores))
+
+    unique = [lab for lab in sorted(set(labels)) if lab != -1]
+    colors = sns.color_palette("deep", len(unique))
+
+    fig, ax = plt.subplots(figsize=(6, 4), dpi=200)
+
+    y_lower = 0
+    for lab, color in zip(unique, colors):
+        vals = scores[np.asarray(labels) == lab]
+        vals = np.sort(vals)
+        n = len(vals)
+        ax.barh(
+            np.arange(y_lower, y_lower + n),
+            vals,
+            color=color,
+            edgecolor="none",
+            height=1.0,
+        )
+        ax.text(-0.02, y_lower + n / 2, str(lab), va="center", ha="right")
+        y_lower += n
+
+    ax.axvline(mean_score, color="k", linestyle="--")
+    ax.set_yticks([])
+    ax.set_xlabel("Silhouette")
+    ax.set_title("Diagramme de silhouette")
+    fig.tight_layout()
+
+    output = Path(output_path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(output, dpi=300)
+    plt.close(fig)
+    return output
+
+
 def segment_profile_table(
     df: pd.DataFrame,
     segment_col: str,
@@ -3942,6 +3990,7 @@ __all__ = [
     "dbscan_evaluation_metrics",
     "plot_cluster_evaluation",
     "plot_combined_silhouette",
+    "plot_silhouette_diagram",
     "plot_pca_stability_bars",
     "plot_pca_individuals",
 ]

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -103,3 +103,12 @@ def test_cluster_evaluation_and_stability_plots():
     figs = pf.plot_pca_stability_bars(metrics)
     for fig in figs.values():
         assert hasattr(fig, "savefig")
+
+
+def test_plot_silhouette_diagram(tmp_path):
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(30, 2))
+    labels = np.repeat([0, 1, 2], 10)
+    out = tmp_path / "sil.png"
+    pf.plot_silhouette_diagram(X, labels, out)
+    assert out.exists() and out.stat().st_size > 0


### PR DESCRIPTION
## Summary
- implement `plot_silhouette_diagram` to visualize per-cluster silhouette scores
- expose new helper in `phase4_functions` API
- test that the silhouette plot is generated

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c694527c083329a54cce0ce3d8128