### PR TITLE
Add scatter plot with cluster ellipses

### DIFF
--- a/phase4_functions.py
+++ b/phase4_functions.py
@@ -2535,6 +2535,7 @@ from matplotlib.patches import Ellipse
 import pandas as pd
 import seaborn as sns
 import numpy as np
+from scipy.stats import chi2
 import io
 from typing import Dict, Any, List, Optional, Sequence
 from sklearn.cluster import KMeans
@@ -3347,6 +3348,90 @@ def plot_pca_individuals(
     return output
 
 
+def plot_scatter_ellipses(
+    coords_df: pd.DataFrame,
+    labels: Sequence[Any] | None = None,
+    *,
+    coverage: float = 0.9,
+    palette: str = "deep",
+    title: str = "",
+    output_path: str | Path = "ellipses.png",
+) -> Path:
+    """Scatter plot with cluster ellipses covering ``coverage`` fraction.
+
+    Parameters
+    ----------
+    coords_df:
+        DataFrame with at least two columns representing the 2D embedding.
+    labels:
+        Optional cluster labels used to colour the points and compute ellipses.
+    coverage:
+        Target coverage fraction for the ellipses assuming a Gaussian model.
+    palette:
+        Name of the seaborn colour palette used for the clusters.
+    title:
+        Title of the figure.
+    output_path:
+        Destination PNG file.
+    """
+
+    if coords_df.shape[1] < 2:
+        raise ValueError("coords_df must have at least two columns")
+
+    x_col, y_col = coords_df.columns[:2]
+    fig, ax = plt.subplots(figsize=(8, 6), dpi=200)
+
+    if labels is None:
+        ax.scatter(coords_df[x_col], coords_df[y_col], s=10, alpha=0.6, color="tab:blue")
+    else:
+        ser = pd.Series(labels, index=coords_df.index, name=getattr(labels, "name", "cluster"))
+        cats = ser.astype("category")
+        colors = sns.color_palette(palette, len(cats.cat.categories))
+        chi2_val = chi2.ppf(coverage, df=2)
+        for color, cat in zip(colors, cats.cat.categories):
+            mask = cats == cat
+            ax.scatter(
+                coords_df.loc[mask, x_col],
+                coords_df.loc[mask, y_col],
+                s=10,
+                alpha=0.6,
+                color=color,
+                label=str(cat),
+            )
+            sub = coords_df.loc[mask, [x_col, y_col]].values
+            if sub.shape[0] > 2:
+                cov = np.cov(sub, rowvar=False)
+                if np.all(np.isfinite(cov)):
+                    vals, vecs = np.linalg.eigh(cov)
+                    order = vals.argsort()[::-1]
+                    vals, vecs = vals[order], vecs[:, order]
+                    angle = np.degrees(np.arctan2(*vecs[:, 0][::-1]))
+                    width, height = 2 * np.sqrt(vals * chi2_val)
+                    ell = Ellipse(
+                        xy=sub.mean(axis=0),
+                        width=width,
+                        height=height,
+                        angle=angle,
+                        edgecolor=color,
+                        facecolor="none",
+                        lw=1.5,
+                        alpha=0.7,
+                    )
+                    ax.add_patch(ell)
+        ax.legend(title=ser.name, bbox_to_anchor=(1.05, 1), loc="upper left")
+
+    ax.set_xlabel(x_col)
+    ax.set_ylabel(y_col)
+    ax.set_title(title)
+    fig.tight_layout()
+
+    output = Path(output_path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(output, dpi=300)
+    plt.close(fig)
+    return output
+
+
 def plot_famd_contributions(contrib: pd.DataFrame, n: int = 10) -> plt.Figure:
     """Return a bar plot of variable contributions to F1 and F2.
 
@@ -3944,6 +4029,7 @@ __all__ = [
     "plot_combined_silhouette",
     "plot_pca_stability_bars",
     "plot_pca_individuals",
+    "plot_scatter_ellipses",
 ]
 
 

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -103,3 +103,11 @@ def test_cluster_evaluation_and_stability_plots():
     figs = pf.plot_pca_stability_bars(metrics)
     for fig in figs.values():
         assert hasattr(fig, "savefig")
+
+
+def test_plot_scatter_ellipses(tmp_path):
+    coords = pd.DataFrame({"X": [0, 1, 0, 1], "Y": [0, 0, 1, 1]})
+    labels = pd.Series([0, 0, 1, 1])
+    out = tmp_path / "ell.png"
+    pf.plot_scatter_ellipses(coords, labels, output_path=out)
+    assert out.exists() and out.stat().st_size > 0


### PR DESCRIPTION
## Summary
- support plotting scatter plots with confidence ellipses
- expose new helper in `phase4_functions.py`
- test the new visualisation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c6955a89083328b1f3e77930a4b0c