### PR TITLE
Add cluster confusion heatmap helper

### DIFF
--- a/cluster_confusion_heatmap.py
+++ b/cluster_confusion_heatmap.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Generate a heatmap comparing two clustering solutions."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pandas as pd
+
+from phase4_functions import (
+    cluster_confusion_table,
+    plot_cluster_confusion_heatmap,
+)
+
+
+def _read_labels(path: Path) -> pd.Series:
+    """Return a label series from ``path`` CSV/Excel file."""
+    if not path.exists():
+        raise FileNotFoundError(path)
+    if path.suffix.lower() == ".csv":
+        df = pd.read_csv(path)
+    else:
+        df = pd.read_excel(path)
+    if df.shape[1] == 1:
+        return df.iloc[:, 0]
+    for col in df.columns:
+        if col.lower() in {"cluster", "label", "labels"}:
+            return df[col]
+    raise ValueError(f"cannot determine label column in {path}")
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Cross-tabulate clustering solutions")
+    parser.add_argument("--labels_a", required=True, help="First labels CSV/Excel")
+    parser.add_argument("--labels_b", required=True, help="Second labels CSV/Excel")
+    parser.add_argument("--output", default="clusters_confusion.png", help="Output PNG path")
+    parser.add_argument("--normalize", action="store_true", help="Show percentages instead of counts")
+    args = parser.parse_args(argv)
+
+    a = _read_labels(Path(args.labels_a))
+    b = _read_labels(Path(args.labels_b))
+    table = cluster_confusion_table(a, b)
+    fig = plot_cluster_confusion_heatmap(
+        table,
+        "Correspondance des clusters",
+        normalize=args.normalize,
+    )
+
+    out = Path(args.output)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out)
+    print(out)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/phase4_functions.py
+++ b/phase4_functions.py
@@ -3065,6 +3065,44 @@ def plot_cluster_segment_heatmap(table: pd.DataFrame, title: str) -> plt.Figure:
     return fig
 
 
+def cluster_confusion_table(
+    labels_a: Sequence[int] | pd.Series,
+    labels_b: Sequence[int] | pd.Series,
+) -> pd.DataFrame:
+    """Return a cross-tabulation of clusters between two solutions."""
+
+    if len(labels_a) != len(labels_b):
+        raise ValueError("labels_a and labels_b must have same length")
+    ser_a = pd.Series(labels_a, name="A")
+    ser_b = pd.Series(labels_b, name="B")
+    return pd.crosstab(ser_a, ser_b)
+
+
+def plot_cluster_confusion_heatmap(
+    table: pd.DataFrame,
+    title: str,
+    *,
+    normalize: bool = False,
+) -> plt.Figure:
+    """Return a heatmap visualising ``table`` counts or percentages."""
+
+    import seaborn as sns
+
+    data = table
+    fmt = "d"
+    if normalize:
+        data = table / table.values.sum()
+        fmt = ".2f"
+
+    fig, ax = plt.subplots(figsize=(8, 6), dpi=200)
+    sns.heatmap(data, annot=True, fmt=fmt, cmap="coolwarm", ax=ax)
+    ax.set_title(title)
+    ax.set_xlabel("Clusters B")
+    ax.set_ylabel("Clusters A")
+    fig.tight_layout()
+    return fig
+
+
 def segment_profile_table(
     df: pd.DataFrame,
     segment_col: str,

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -70,6 +70,15 @@ def test_cluster_segment_table_and_heatmap():
     assert hasattr(fig, "savefig")
 
 
+def test_cluster_confusion_table_and_heatmap():
+    a = np.array([0, 0, 1, 1])
+    b = np.array([1, 0, 1, 0])
+    tab = pf.cluster_confusion_table(a, b)
+    assert tab.loc[0, 0] == 1
+    fig = pf.plot_cluster_confusion_heatmap(tab, "test")
+    assert hasattr(fig, "savefig")
+
+
 def test_plot_clusters_by_k():
     rng = np.random.default_rng(0)
     X = pd.DataFrame(rng.normal(size=(20, 2)), columns=["F1", "F2"])


### PR DESCRIPTION
## Summary
- add `cluster_confusion_table` and `plot_cluster_confusion_heatmap` utilities
- provide command line script `cluster_confusion_heatmap.py`
- test the new functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c69639e848332a54c080f6e92634c