### PR TITLE
Add table of contents to generated PDF reports

### DIFF
--- a/generate_phase4_report.py
+++ b/generate_phase4_report.py
@@ -245,6 +245,48 @@ def export_report_to_pdf(
     for k in segment_figs:
         del remaining[k]
 
+    tmp_paths: list[str] = []
+    pages: list[tuple[str, str]] = []
+    toc: list[tuple[str, int]] = []
+
+    for dataset in sorted(grouped):
+        for method in sorted(grouped[dataset]):
+            items = grouped[dataset][method]
+            figs = [
+                (
+                    _combine_scatter(items.get("scatter_2d"), items.get("scatter_3d")),
+                    "Nuages de points bruts",
+                )
+            ]
+            for algo in ["kmeans", "agglomerative", "gmm", "spectral"]:
+                key = f"{algo}_kgrid"
+                if key in items:
+                    figs.append((items[key], f"Clusters {algo}"))
+            figs += [
+                (items.get("cluster_grid"), "Nuages clusterisés"),
+                (items.get("analysis_summary"), "Analyse détaillée"),
+            ]
+
+            first = True
+            for fig, label in figs:
+                img = _fig_to_path(fig, tmp_paths)
+                if img:
+                    if first:
+                        toc.append((f"{dataset} – {method.upper()}", len(pages) + 3))
+                        first = False
+                    pages.append((f"{dataset} – {method.upper()} – {label}", img))
+
+    for name, fig in segment_figs.items():
+        img = _fig_to_path(fig, tmp_paths)
+        if img:
+            ds = name.rsplit("_segment_summary_2", 1)[0]
+            pages.append((f"% NA par segment – {ds}", img))
+
+    for name, fig in remaining.items():
+        img = _fig_to_path(fig, tmp_paths)
+        if img:
+            pages.append((name, img))
+
     try:
         from fpdf import FPDF  # type: ignore
 
@@ -261,49 +303,18 @@ def export_report_to_pdf(
         today = datetime.datetime.now().strftime("%Y-%m-%d")
         pdf.cell(0, 10, f"Généré le {today}", ln=1, align="C")
 
+        pdf.add_page()
+        pdf.set_font("Helvetica", "B", 16)
+        pdf.cell(0, 10, "Table des matières", ln=1, align="C")
+        pdf.ln(4)
+        pdf.set_font("Helvetica", size=12)
+        for title, pg in toc:
+            pdf.cell(0, 8, f"{title} ...... {pg}", ln=1)
 
-        # Tables are intentionally ignored to keep the report concise.
-
-        tmp_paths: list[str] = []
-
-        for dataset in sorted(grouped):
-            for method in sorted(grouped[dataset]):
-                items = grouped[dataset][method]
-                pages = [
-                    (
-                        _combine_scatter(items.get("scatter_2d"), items.get("scatter_3d")),
-                        "Nuages de points bruts",
-                    )
-                ]
-                for algo in ["kmeans", "agglomerative", "gmm", "spectral"]:
-                    key = f"{algo}_kgrid"
-                    if key in items:
-                        pages.append((items[key], f"Clusters {algo}"))
-                pages += [
-                    (items.get("cluster_grid"), "Nuages clusterisés"),
-                    (items.get("analysis_summary"), "Analyse détaillée"),
-                ]
-                for fig, label in pages:
-                    img = _fig_to_path(fig, tmp_paths)
-                    if img:
-                        pdf.add_page()
-                        _add_title(f"{dataset} – {method.upper()} – {label}")
-                        pdf.image(img, w=180)
-
-        for name, fig in segment_figs.items():
-            img = _fig_to_path(fig, tmp_paths)
-            if img:
-                pdf.add_page()
-                ds = name.rsplit("_segment_summary_2", 1)[0]
-                _add_title(f"% NA par segment – {ds}")
-                pdf.image(img, w=180)
-
-        for name, fig in remaining.items():
-            img = _fig_to_path(fig, tmp_paths)
-            if img:
-                pdf.add_page()
-                _add_title(name)
-                pdf.image(img, w=180)
+        for title, img in pages:
+            pdf.add_page()
+            _add_title(title)
+            pdf.image(img, w=180)
 
         pdf.output(str(out))
 
@@ -325,48 +336,28 @@ def export_report_to_pdf(
             pdf_backend.savefig(fig, dpi=300)
             plt.close(fig)
 
-            def _save_page(title: str, fig: plt.Figure | Path | str | None) -> None:
-                if fig is None:
-                    return
-                if isinstance(fig, (str, Path)):
-                    img = plt.imread(fig)
-                    f, ax = plt.subplots()
-                    ax.imshow(img)
-                    ax.axis("off")
-                    f.suptitle(title, fontsize=12)
-                    pdf_backend.savefig(f, dpi=300)
-                    plt.close(f)
-                else:
-                    fig.suptitle(title, fontsize=12)
-                    pdf_backend.savefig(fig, dpi=300)
-                    plt.close(fig)
+            fig, ax = plt.subplots(figsize=(11.69, 8.27), dpi=200)
+            ax.axis("off")
+            ax.text(0.5, 0.9, "Table des matières", fontsize=16, ha="center", va="top")
+            y = 0.8
+            for title, pg in toc:
+                ax.text(0.05, y, title, ha="left", va="top", fontsize=12)
+                ax.text(0.95, y, str(pg), ha="right", va="top", fontsize=12)
+                y -= 0.04
+            pdf_backend.savefig(fig, dpi=300)
+            plt.close(fig)
 
-            for dataset in sorted(grouped):
-                for method in sorted(grouped[dataset]):
-                    items = grouped[dataset][method]
-                    pages = [
-                        (
-                            _combine_scatter(items.get("scatter_2d"), items.get("scatter_3d")),
-                            "Nuages de points bruts",
-                        )
-                    ]
-                    for algo in ["kmeans", "agglomerative", "gmm", "spectral"]:
-                        key = f"{algo}_kgrid"
-                        if key in items:
-                            pages.append((items[key], f"Clusters {algo}"))
-                    pages += [
-                        (items.get("cluster_grid"), "Nuages clusterisés"),
-                        (items.get("analysis_summary"), "Analyse détaillée"),
-                    ]
-                    for fig, label in pages:
-                        _save_page(f"{dataset} – {method.upper()} – {label}", fig)
+            def _save_page(title: str, path: str) -> None:
+                img = plt.imread(path)
+                f, ax = plt.subplots()
+                ax.imshow(img)
+                ax.axis("off")
+                f.suptitle(title, fontsize=12)
+                pdf_backend.savefig(f, dpi=300)
+                plt.close(f)
 
-            for name, fig in segment_figs.items():
-                ds = name.rsplit("_segment_summary_2", 1)[0]
-                _save_page(f"% NA par segment – {ds}", fig)
-
-            for name, fig in remaining.items():
-                _save_page(name, fig)
+            for title, img in pages:
+                _save_page(title, img)
 
 
             # Tables used to be converted to figures and appended here, but


### PR DESCRIPTION
## Summary
- build list of report pages ahead of time
- insert table of contents when exporting Phase 4 reports
- include fallback rendering for non-FPDF environments

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c69a17df08332b611d0cbe6ea7053