### PR TITLE
Add XGBoost training utilities

### DIFF
--- a/pred/__init__.py
+++ b/pred/__init__.py
@@ -6,6 +6,7 @@ from .aggregate_revenue import (
     build_timeseries,
 )
 from .preprocess_timeseries import preprocess_series, preprocess_all
+from .train_xgboost import train_xgb_model, train_all_granularities
 
 __all__ = [
     "load_won_opportunities",
@@ -13,4 +14,6 @@ __all__ = [
     "build_timeseries",
     "preprocess_series",
     "preprocess_all",
+    "train_xgb_model",
+    "train_all_granularities",
 ]

--- a/pred/train_xgboost.py
+++ b/pred/train_xgboost.py
@@ -1,0 +1,90 @@
+"""XGBoost regression models for aggregated revenue forecasting."""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import pandas as pd
+from xgboost import XGBRegressor
+
+
+# ---------------------------------------------------------------------------
+# Supervised transformation
+# ---------------------------------------------------------------------------
+
+def _to_supervised(series: pd.Series, n_lags: int, *, add_time_features: bool = False) -> Tuple[pd.DataFrame, pd.Series]:
+    """Convert ``series`` to a supervised learning dataset.
+
+    Parameters
+    ----------
+    series:
+        Time series indexed by ``DatetimeIndex``.
+    n_lags:
+        Number of past observations to use as predictors.
+    add_time_features:
+        If ``True`` add the month/quarter as an additional feature to help
+        capture seasonality.
+    """
+    df = pd.DataFrame({"y": series})
+    for i in range(1, n_lags + 1):
+        df[f"lag{i}"] = series.shift(i)
+
+    if add_time_features:
+        # Add month or quarter depending on the frequency
+        if series.index.freqstr and series.index.freqstr.startswith("M"):
+            df["month"] = series.index.month
+            time_cols = ["month"]
+        elif series.index.freqstr and series.index.freqstr.startswith("Q"):
+            df["quarter"] = series.index.quarter
+            time_cols = ["quarter"]
+        else:  # yearly or unknown frequency
+            df["year"] = series.index.year
+            time_cols = ["year"]
+    else:
+        time_cols = []
+
+    df = df.dropna()
+    feature_cols = [f"lag{i}" for i in range(1, n_lags + 1)] + time_cols
+    X = df[feature_cols]
+    y = df["y"]
+    return X, y
+
+
+# ---------------------------------------------------------------------------
+# Training helpers
+# ---------------------------------------------------------------------------
+
+def train_xgb_model(series: pd.Series, n_lags: int, *, add_time_features: bool = False, **model_params: int) -> Tuple[XGBRegressor, float]:
+    """Train an :class:`xgboost.XGBRegressor` on ``series``.
+
+    Returns the fitted model and the training score (R^2).
+    """
+    X, y = _to_supervised(series, n_lags, add_time_features=add_time_features)
+    model = XGBRegressor(
+        objective="reg:squarederror",
+        n_estimators=100,
+        max_depth=3,
+        learning_rate=0.1,
+        random_state=42,
+        **model_params,
+    )
+    model.fit(X, y)
+    return model, model.score(X, y)
+
+
+def train_all_granularities(
+    monthly: pd.Series,
+    quarterly: pd.Series,
+    yearly: pd.Series,
+) -> Tuple[Tuple[XGBRegressor, float], Tuple[XGBRegressor, float], Tuple[XGBRegressor, float]]:
+    """Return XGBoost models fitted on monthly, quarterly and yearly series."""
+    m_model, m_score = train_xgb_model(monthly, 12, add_time_features=True)
+    q_model, q_score = train_xgb_model(quarterly, 4, add_time_features=True)
+    y_model, y_score = train_xgb_model(yearly, 3)
+    return (m_model, m_score), (q_model, q_score), (y_model, y_score)
+
+
+__all__ = [
+    "train_xgb_model",
+    "train_all_granularities",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,8 @@ pacmap~=0.8.0
 pypdf2~=3.0.1
 pytest~=8.3.5
 
+xgboost~=2.0
+
 flake8
 
 pathlib~=1.0.1


### PR DESCRIPTION
## Summary
- implement XGBoost-based regression model training for revenue forecasting
- export new utilities from `pred/__init__.py`
- add `xgboost` to requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d5934219083329c3733e614a67c52