### PR TITLE
Ensure __init__ exposes all models

### DIFF
--- a/pred/__init__.py
+++ b/pred/__init__.py
@@ -13,6 +13,9 @@ from .lstm_forecast import (
     train_lstm_model,
     quick_predict_check,
 )
+from .prophet_models import fit_prophet_models
+from .train_arima import fit_all_arima
+from .train_xgboost import train_xgb_model, train_all_granularities
 
 __all__ = [
     "load_won_opportunities",
@@ -20,6 +23,10 @@ __all__ = [
     "build_timeseries",
     "preprocess_series",
     "preprocess_all",
+    "fit_prophet_models",
+    "fit_all_arima",
+    "train_xgb_model",
+    "train_all_granularities",
     "create_lstm_sequences",
     "scale_lstm_data",
     "build_lstm_model",


### PR DESCRIPTION
## Summary
- keep prediction module neutral by exporting Prophet, ARIMA, and XGBoost helpers alongside LSTM utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d5c015d988332995aa9f9668408e1