### PR TITLE
Add performance comparison utilities

### DIFF
--- a/pred/__init__.py
+++ b/pred/__init__.py
@@ -13,6 +13,7 @@ from .lstm_forecast import (
     train_lstm_model,
     quick_predict_check,
 )
+from .compare_granularities import build_performance_table, plot_metric_comparison
 
 __all__ = [
     "load_won_opportunities",
@@ -25,4 +26,6 @@ __all__ = [
     "build_lstm_model",
     "train_lstm_model",
     "quick_predict_check",
+    "build_performance_table",
+    "plot_metric_comparison",
 ]

--- a/pred/compare_granularities.py
+++ b/pred/compare_granularities.py
@@ -1,0 +1,55 @@
+"""Utilities to summarise forecast performance across time granularities."""
+
+from __future__ import annotations
+
+from typing import Dict, Mapping
+
+import pandas as pd
+import matplotlib.pyplot as plt
+
+
+MetricDict = Mapping[str, float]
+ModelResults = Mapping[str, Mapping[str, MetricDict]]
+
+
+def build_performance_table(results: ModelResults) -> pd.DataFrame:
+    """Return DataFrame of metrics organised by model and frequency.
+
+    Parameters
+    ----------
+    results:
+        Mapping where ``results[model][freq]`` gives a mapping of metric names
+        to values. ``freq`` should be one of ``{"monthly", "quarterly", "yearly"}``.
+
+    Returns
+    -------
+    pd.DataFrame
+        Table with models as index and columns like ``MAE_monthly``,
+        ``RMSE_quarterly`` etc.
+    """
+    frames = []
+    for freq in ["monthly", "quarterly", "yearly"]:
+        data = {
+            model: metrics.get(freq, {})
+            for model, metrics in results.items()
+        }
+        df = pd.DataFrame.from_dict(data, orient="index")
+        df.columns = [f"{col}_{freq}" for col in df.columns]
+        frames.append(df)
+    table = pd.concat(frames, axis=1)
+    return table
+
+
+def plot_metric_comparison(table: pd.DataFrame, metric: str) -> None:
+    """Display bar chart of ``metric`` for each model and frequency."""
+    cols = [f"{metric}_monthly", f"{metric}_quarterly", f"{metric}_yearly"]
+    subset = table[cols]
+    subset.plot(kind="bar")
+    plt.ylabel(metric)
+    plt.title(f"Comparison of {metric} across granularities")
+    plt.xticks(rotation=45, ha="right")
+    plt.tight_layout()
+    plt.show()
+
+
+__all__ = ["build_performance_table", "plot_metric_comparison"]

--- a/tests/test_compare_granularities.py
+++ b/tests/test_compare_granularities.py
@@ -1,0 +1,33 @@
+from pred.compare_granularities import build_performance_table
+
+
+def test_build_performance_table_basic():
+    results = {
+        "ARIMA": {
+            "monthly": {"MAE": 1.0, "RMSE": 2.0, "MAPE": 3.0},
+            "quarterly": {"MAE": 0.5, "RMSE": 1.5, "MAPE": 2.5},
+            "yearly": {"MAE": 2.0, "RMSE": 3.0, "MAPE": 4.0},
+        },
+        "Prophet": {
+            "monthly": {"MAE": 1.1, "RMSE": 2.1, "MAPE": 3.1},
+            "quarterly": {"MAE": 0.6, "RMSE": 1.6, "MAPE": 2.6},
+            "yearly": {"MAE": 2.1, "RMSE": 3.1, "MAPE": 4.1},
+        },
+    }
+
+    table = build_performance_table(results)
+    assert list(table.index) == ["ARIMA", "Prophet"]
+    expected_cols = {
+        "MAE_monthly",
+        "RMSE_monthly",
+        "MAPE_monthly",
+        "MAE_quarterly",
+        "RMSE_quarterly",
+        "MAPE_quarterly",
+        "MAE_yearly",
+        "RMSE_yearly",
+        "MAPE_yearly",
+    }
+    assert set(table.columns) == expected_cols
+    assert table.loc["ARIMA", "MAE_monthly"] == 1.0
+    assert table.loc["Prophet", "MAPE_yearly"] == 4.1


### PR DESCRIPTION
## Summary
- add `compare_granularities` module with helpers to build a table from metrics
- export the new helpers from `pred.__init__`
- test `build_performance_table` on a small mock dictionary

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d5d2feb9c83329021e4238d431d8e