### PR TITLE
Fix pred init imports

### DIFF
--- a/pred/__init__.py
+++ b/pred/__init__.py
@@ -13,6 +13,9 @@ from .lstm_forecast import (
     train_lstm_model,
     quick_predict_check,
 )
+from .prophet_models import fit_prophet_models
+from .train_arima import fit_all_arima
+from .train_xgboost import train_xgb_model, train_all_granularities
 from .compare_granularities import build_performance_table, plot_metric_comparison
 
 __all__ = [


### PR DESCRIPTION
## Summary
- fix missing imports for Prophet, ARIMA and XGBoost helpers in `pred/__init__.py`

## Testing
- `flake8 pred/__init__.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'prophet')*

------
https://chatgpt.com/codex/tasks/task_e_683d6264784c8332acf33790f81750fd