### PR TITLE
Add future forecasting utilities

### DIFF
--- a/pred/__init__.py
+++ b/pred/__init__.py
@@ -17,6 +17,12 @@ from .prophet_models import fit_prophet_models
 from .train_arima import fit_all_arima
 from .train_xgboost import train_xgb_model, train_all_granularities
 from .compare_granularities import build_performance_table, plot_metric_comparison
+from .future_forecast import (
+    forecast_arima,
+    forecast_prophet,
+    forecast_xgb,
+    forecast_lstm,
+)
 
 __all__ = [
     "load_won_opportunities",
@@ -35,4 +41,8 @@ __all__ = [
     "quick_predict_check",
     "build_performance_table",
     "plot_metric_comparison",
+    "forecast_arima",
+    "forecast_prophet",
+    "forecast_xgb",
+    "forecast_lstm",
 ]

--- a/pred/future_forecast.py
+++ b/pred/future_forecast.py
@@ -1,0 +1,130 @@
+"""Forecast future aggregated revenue using trained models."""
+
+from __future__ import annotations
+
+import pandas as pd
+from pmdarima.arima import ARIMA
+from prophet import Prophet
+from xgboost import XGBRegressor
+from sklearn.preprocessing import MinMaxScaler
+
+from .train_xgboost import _to_supervised
+
+
+# ---------------------------------------------------------------------------
+# ARIMA / SARIMA forecast
+# ---------------------------------------------------------------------------
+
+def forecast_arima(model: ARIMA, series: pd.Series, periods: int) -> pd.DataFrame:
+    """Return ARIMA predictions with confidence intervals."""
+    freq = series.index.freq or pd.infer_freq(series.index)
+    if freq is None:
+        raise ValueError("Series index must have a frequency")
+    start = series.index[-1] + pd.tseries.frequencies.to_offset(freq)
+    idx = pd.date_range(start=start, periods=periods, freq=freq)
+
+    preds, conf = model.predict(n_periods=periods, return_conf_int=True)
+    return pd.DataFrame(
+        {
+            "forecast": preds,
+            "lower_ci": conf[:, 0],
+            "upper_ci": conf[:, 1],
+        },
+        index=idx,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Prophet forecast
+# ---------------------------------------------------------------------------
+
+def forecast_prophet(model: Prophet, series: pd.Series, periods: int) -> pd.DataFrame:
+    """Return Prophet predictions with confidence intervals."""
+    freq = series.index.freq or pd.infer_freq(series.index) or "M"
+    future = model.make_future_dataframe(periods=periods, freq=freq)
+    forecast = model.predict(future)
+    subset = forecast.tail(periods)[["ds", "yhat", "yhat_lower", "yhat_upper"]]
+    subset.columns = ["ds", "forecast", "lower_ci", "upper_ci"]
+    subset = subset.set_index("ds")
+    return subset
+
+
+# ---------------------------------------------------------------------------
+# XGBoost forecast (approximate interval)
+# ---------------------------------------------------------------------------
+
+def forecast_xgb(
+    model: XGBRegressor,
+    series: pd.Series,
+    periods: int,
+    *,
+    n_lags: int,
+    rmse: float,
+    add_time_features: bool = True,
+) -> pd.DataFrame:
+    """Iteratively forecast with XGBoost and approximate confidence bounds."""
+    freq = series.index.freq or pd.infer_freq(series.index)
+    if freq is None:
+        raise ValueError("Series index must have a frequency")
+    start = series.index[-1] + pd.tseries.frequencies.to_offset(freq)
+    idx = pd.date_range(start=start, periods=periods, freq=freq)
+
+    history = series.copy()
+    preds, lower, upper = [], [], []
+    for i in range(periods):
+        X_hist, _ = _to_supervised(history, n_lags, add_time_features=add_time_features)
+        X_pred = X_hist.iloc[-1:]
+        pred = float(model.predict(X_pred)[0])
+        preds.append(pred)
+        lower.append(pred - 1.96 * rmse)
+        upper.append(pred + 1.96 * rmse)
+        history.loc[idx[i]] = pred
+
+    return pd.DataFrame(
+        {"forecast": preds, "lower_ci": lower, "upper_ci": upper}, index=idx
+    )
+
+
+# ---------------------------------------------------------------------------
+# LSTM forecast (approximate interval)
+# ---------------------------------------------------------------------------
+
+def forecast_lstm(
+    model,
+    scaler: MinMaxScaler,
+    series: pd.Series,
+    periods: int,
+    *,
+    window_size: int,
+    rmse: float,
+) -> pd.DataFrame:
+    """Iteratively forecast with LSTM and approximate confidence bounds."""
+    freq = series.index.freq or pd.infer_freq(series.index)
+    if freq is None:
+        raise ValueError("Series index must have a frequency")
+    start = series.index[-1] + pd.tseries.frequencies.to_offset(freq)
+    idx = pd.date_range(start=start, periods=periods, freq=freq)
+
+    history = series.copy()
+    preds, lower, upper = [], [], []
+    for i in range(periods):
+        seq = history.values[-window_size:].reshape(1, window_size, 1)
+        seq_s = scaler.transform(seq.reshape(-1, 1)).reshape(1, window_size, 1)
+        pred_s = model.predict(seq_s, verbose=0)[0, 0]
+        pred = scaler.inverse_transform([[pred_s]])[0, 0]
+        preds.append(float(pred))
+        lower.append(pred - 1.96 * rmse)
+        upper.append(pred + 1.96 * rmse)
+        history.loc[idx[i]] = pred
+
+    return pd.DataFrame(
+        {"forecast": preds, "lower_ci": lower, "upper_ci": upper}, index=idx
+    )
+
+
+__all__ = [
+    "forecast_arima",
+    "forecast_prophet",
+    "forecast_xgb",
+    "forecast_lstm",
+]


### PR DESCRIPTION
## Summary
- add `future_forecast` module for future revenue predictions with ARIMA, Prophet, XGBoost and LSTM
- expose new helpers in `pred.__init__`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'prophet')*

------
https://chatgpt.com/codex/tasks/task_e_683d65aa255483328694f7b98e6ad0dc