### PR TITLE
Replace pmdarima with statsforecast

### DIFF
--- a/pred/__init__.py
+++ b/pred/__init__.py
@@ -29,7 +29,7 @@ try:  # Optional dependency
 except Exception as _exc_arima:  # pragma: no cover - optional
 
     def fit_all_arima(*_a, **_k):
-        raise ImportError("pmdarima is required for fit_all_arima") from _exc_arima
+        raise ImportError("statsforecast is required for fit_all_arima") from _exc_arima
 
 
 from .train_xgboost import train_xgb_model, train_all_granularities

--- a/pred/evaluate_models.py
+++ b/pred/evaluate_models.py
@@ -11,7 +11,7 @@ from sklearn.metrics import (
     mean_squared_error,
     mean_absolute_percentage_error,
 )
-from pmdarima import auto_arima
+from statsforecast.models import AutoARIMA
 from prophet import Prophet
 from xgboost import XGBRegressor
 
@@ -42,15 +42,10 @@ def _evaluate_arima(series: pd.Series, test_size: int, *, seasonal: bool, m: int
     history = train.copy()
     preds: List[float] = []
     for t, val in enumerate(test):
-        model = auto_arima(
-            history,
-            seasonal=seasonal,
-            m=m,
-            error_action="ignore",
-            suppress_warnings=True,
-            stepwise=True,
-        )
-        pred = model.predict()[0]
+        season_length = m if seasonal else 1
+        model = AutoARIMA(season_length=season_length)
+        model.fit(history.values)
+        pred = float(model.predict(h=1)[0])
         preds.append(pred)
         history.loc[test.index[t]] = val
     return _compute_metrics(test.values, preds)

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,6 @@ joblib~=1.5.1
 
 fpdf
 prophet
-pmdarima
+statsforecast
 xgboost
 catboost


### PR DESCRIPTION
## Summary
- switch ARIMA code to use statsforecast instead of pmdarima
- update forecast helpers for statsforecast
- update metrics evaluation to use statsforecast
- adjust optional import message
- remove pmdarima from requirements and add statsforecast

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d86ca3710833298d59efb87ed6399