### PR TITLE
Fix forecasting code warnings and features mismatch

### DIFF
--- a/pred/aggregate_revenue.py
+++ b/pred/aggregate_revenue.py
@@ -53,9 +53,9 @@ def aggregate_revenue(df: pd.DataFrame, amount_col: str) -> Tuple[pd.Series, pd.
     Missing periods are filled with 0 so that the returned series have
     continuous indices.
     """
-    monthly = df[amount_col].resample("M").sum().fillna(0)
-    quarterly = df[amount_col].resample("Q").sum().fillna(0)
-    yearly = df[amount_col].resample("A").sum().fillna(0)
+    monthly = df[amount_col].resample("ME").sum().fillna(0)
+    quarterly = df[amount_col].resample("QE").sum().fillna(0)
+    yearly = df[amount_col].resample("YE").sum().fillna(0)
     return monthly, quarterly, yearly
 
 

--- a/pred/preprocess_timeseries.py
+++ b/pred/preprocess_timeseries.py
@@ -70,9 +70,9 @@ def preprocess_all(
     yearly: pd.Series,
 ) -> Tuple[pd.Series, pd.Series, pd.Series]:
     """Clean monthly, quarterly and yearly time series."""
-    monthly_clean = preprocess_series(monthly, freq="M")
-    quarterly_clean = preprocess_series(quarterly, freq="Q")
-    yearly_clean = preprocess_series(yearly, freq="A")
+    monthly_clean = preprocess_series(monthly, freq="ME")
+    quarterly_clean = preprocess_series(quarterly, freq="QE")
+    yearly_clean = preprocess_series(yearly, freq="YE")
     return monthly_clean, quarterly_clean, yearly_clean
 
 


### PR DESCRIPTION
## Summary
- compute RMSE without using the `squared` kwarg for backwards compatibility
- preserve frequency when extending time series for XGBoost
- switch monthly/quarterly/yearly frequencies to `ME`, `QE`, `YE`
- update Prophet evaluation to default to `ME`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683da5ed80c483328b784c0e4ba6d806