### PR TITLE
Add improved revenue preprocessing and safe metrics

### DIFF
--- a/pred/__init__.py
+++ b/pred/__init__.py
@@ -5,7 +5,11 @@ from .aggregate_revenue import (
     aggregate_revenue,
     build_timeseries,
 )
-from .preprocess_timeseries import preprocess_series, preprocess_all
+from .preprocess_timeseries import (
+    load_and_aggregate,
+    preprocess_series,
+    preprocess_all,
+)
 from .lstm_forecast import (
     create_lstm_sequences,
     scale_lstm_data,
@@ -57,6 +61,7 @@ __all__ = [
     "load_won_opportunities",
     "aggregate_revenue",
     "build_timeseries",
+    "load_and_aggregate",
     "preprocess_series",
     "preprocess_all",
     "fit_all_arima",

--- a/pred/run_all.py
+++ b/pred/run_all.py
@@ -19,8 +19,7 @@ from typing import Dict
 
 import yaml
 
-from .aggregate_revenue import build_timeseries
-from .preprocess_timeseries import preprocess_all
+from .preprocess_timeseries import load_and_aggregate, preprocess_all
 from .evaluate_models import (
     _evaluate_arima,
     _evaluate_prophet,
@@ -117,7 +116,15 @@ def main(argv: list[str] | None = None) -> None:
     csv_path = Path(cfg.get("input_file_cleaned_3_multi", "cleaned_3_multi.csv"))
     output_dir = Path(cfg.get("output_dir", "."))
 
-    monthly, quarterly, yearly = build_timeseries(csv_path)
+    cfg_timeseries = {
+        "csv_path": csv_path,
+        "date_col": cfg.get("date_col", "Date de fin actualisée"),
+        "status_col": cfg.get("status_col", "Statut commercial"),
+        "won_value": cfg.get("won_value", "Gagné"),
+        "amount_col": cfg.get("amount_col", "Total recette réalisé"),
+    }
+
+    monthly, quarterly, yearly = load_and_aggregate(cfg_timeseries)
     monthly, quarterly, yearly = preprocess_all(monthly, quarterly, yearly)
 
     results = evaluate_all(monthly, quarterly, yearly, jobs=args.jobs)


### PR DESCRIPTION
## Summary
- add `load_and_aggregate` helper in `preprocess_timeseries` to build monthly/quarterly/yearly series directly from CSV
- update `run_all` to use the new loader
- compute metrics with `safe_mape` in `evaluate_models`
- expose `load_and_aggregate` from package

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683dae3be8a883329e8a9f274f252c96