### PR TITLE
Add lead scoring pipeline script

### DIFF
--- a/run_lead_scoring.py
+++ b/run_lead_scoring.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+"""Master script orchestrating the lead scoring pipeline."""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+from pathlib import Path
+import yaml
+
+from preprocess_lead_scoring import preprocess
+from train_lead_models import (
+    train_xgboost_lead,
+    train_catboost_lead,
+    train_lstm_lead,
+    train_arima_conv_rate,
+    train_prophet_conv_rate,
+)
+from evaluate_lead_models import evaluate_all
+
+
+def main(argv: list[str] | None = None) -> None:
+    p = argparse.ArgumentParser(description="Run full lead scoring pipeline")
+    p.add_argument("--config", default="config.yaml", help="Path to YAML config")
+    args = p.parse_args(argv)
+
+    with open(args.config, "r", encoding="utf-8") as fh:
+        cfg = yaml.safe_load(fh)
+
+    (
+        X_train,
+        y_train,
+        X_val,
+        y_val,
+        X_test,
+        y_test,
+        ts_conv_train,
+        ts_conv_test,
+        df_prophet_train,
+    ) = preprocess(cfg)
+
+    # ------------------------------------------------------------------
+    # Classification models
+    # ------------------------------------------------------------------
+    with concurrent.futures.ThreadPoolExecutor(max_workers=3) as ex:
+        fut_xgb = ex.submit(train_xgboost_lead, cfg)
+        fut_cat = ex.submit(train_catboost_lead, cfg)
+        fut_lstm = ex.submit(train_lstm_lead, cfg)
+
+        model_xgb, metrics_xgb = fut_xgb.result()
+        model_cat, metrics_cat = fut_cat.result()
+        model_lstm, metrics_lstm = fut_lstm.result()
+
+    # ------------------------------------------------------------------
+    # Forecast models
+    # ------------------------------------------------------------------
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as ex:
+        fut_arima = ex.submit(train_arima_conv_rate, cfg)
+        fut_prophet = ex.submit(train_prophet_conv_rate, cfg)
+
+        model_arima, metrics_arima = fut_arima.result()
+        model_prophet, metrics_prophet = fut_prophet.result()
+
+    df_metrics = evaluate_all(cfg)
+    print(df_metrics.to_string(index=False))
+
+    lead_cfg = cfg.get("lead_scoring", {})
+    out_dir = Path(lead_cfg.get("output_dir", cfg.get("output_dir", ".")))
+    report_file = out_dir / "lead_scoring_report.txt"
+    try:
+        report_file.write_text(df_metrics.to_string(index=False))
+    except Exception:
+        pass
+
+
+if __name__ == "__main__":  # pragma: no cover - simple script
+    main()


### PR DESCRIPTION
## Summary
- add a convenience `preprocess` function to load data produced during preprocessing
- implement XGBoost and CatBoost training utilities for lead scoring
- expose all helpers in `train_lead_models`
- add `run_lead_scoring.py` master script to orchestrate the whole pipeline

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683de62b04508332ad53fa00a7000d80