### PR TITLE
Fix run_all to explicitly clean dates first

### DIFF
--- a/pred/run_all.py
+++ b/pred/run_all.py
@@ -147,7 +147,14 @@ def main(argv: list[str] | None = None) -> None:
     csv_path = Path(cfg.get("input_file_cleaned_3_multi", "cleaned_3_multi.csv"))
     output_dir = Path(cfg.get("output_dir", "."))
 
+    # ------------------------------------------------------------------
+    # Stage 1 - cleaning closing dates before any other transformation
+    # ------------------------------------------------------------------
     monthly, quarterly, yearly = preprocess_dates(csv_path, output_dir)
+
+    # ------------------------------------------------------------------
+    # Stage 2 - generic preprocessing of the aggregated time series
+    # ------------------------------------------------------------------
     monthly, quarterly, yearly = preprocess_all(monthly, quarterly, yearly)
 
     results = evaluate_all(monthly, quarterly, yearly, jobs=args.jobs)


### PR DESCRIPTION
## Summary
- comment the pipeline in `run_all` to clarify when date cleaning occurs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683ed30f9e188332aedd07841e252f76