### PR TITLE
Fix run_all to explicitly clean dates first

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,8 +275,11 @@ executed sequentially. Outputs are written in the directory set by
 
 Le script `pred/run_all.py` orchestre l'ensemble des fonctions du dossier
 `pred`. Il charge le chemin du fichier ``cleaned_3_multi`` à partir de
-`config.yaml`, nettoie d'abord les dates de clôture grâce à `preprocess_dates`,
-construit les séries temporelles de revenu, les prétraite puis
+`config.yaml`, nettoie d'abord les dates de clôture grâce à `preprocess_dates`.
+Ce nettoyage est la toute première étape du pipeline avant toute autre
+transformation et renvoie directement les séries temporelles agrégées
+utilisées par `preprocess_all`. Il construit ensuite les séries temporelles de
+revenu, les prétraite puis
 évalue tous les modèles (ARIMA, Prophet, XGBoost et LSTM). Le tableau
 résumant les performances est sauvegardé dans ``model_performance.csv`` dans
 le dossier ``output_dir`` défini dans la configuration.

--- a/pred/run_all.py
+++ b/pred/run_all.py
@@ -147,7 +147,14 @@ def main(argv: list[str] | None = None) -> None:
     csv_path = Path(cfg.get("input_file_cleaned_3_multi", "cleaned_3_multi.csv"))
     output_dir = Path(cfg.get("output_dir", "."))
 
+    # ------------------------------------------------------------------
+    # Stage 1 - cleaning closing dates before any other transformation
+    # ------------------------------------------------------------------
     monthly, quarterly, yearly = preprocess_dates(csv_path, output_dir)
+
+    # ------------------------------------------------------------------
+    # Stage 2 - generic preprocessing of the aggregated time series
+    # ------------------------------------------------------------------
     monthly, quarterly, yearly = preprocess_all(monthly, quarterly, yearly)
 
     results = evaluate_all(monthly, quarterly, yearly, jobs=args.jobs)


### PR DESCRIPTION
## Summary
- comment the pipeline in `run_all` to clarify when date cleaning occurs
- clarify the README to note that date cleaning outputs aggregated time series

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_683ed30f9e188332aedd07841e252f76