### PR TITLE
Fix NaN in conversion rate

### DIFF
--- a/pred_lead_scoring/preprocess_lead_scoring.py
+++ b/pred_lead_scoring/preprocess_lead_scoring.py
@@ -177,8 +177,8 @@ def _encode_features(
 def _conversion_time_series(df: pd.DataFrame) -> pd.DataFrame:
     df_closed = df[df["Statut commercial"].notna()].copy()
     df_closed = df_closed.set_index("Date de fin actualisée")
-    ts = df_closed["is_won"].resample("M").agg(["sum", "count"])
-    ts["conv_rate"] = ts["sum"] / ts["count"]
+    ts = df_closed["is_won"].resample("M").agg(["sum", "count"]).fillna(0.0)
+    ts["conv_rate"] = np.where(ts["count"] > 0, ts["sum"] / ts["count"], 0.0)
     return ts
 
 

--- a/pred_lead_scoring/train_lead_models.py
+++ b/pred_lead_scoring/train_lead_models.py
@@ -267,6 +267,9 @@ def train_arima_conv_rate(
             data_dir / "ts_conv_rate_test.csv", index_col=0, parse_dates=True
         )["conv_rate"]
 
+    ts_conv_rate_train = ts_conv_rate_train.fillna(0.0)
+    ts_conv_rate_test = ts_conv_rate_test.fillna(0.0)
+
     # Determine ARIMA order either from config or via automatic search
     order = lead_cfg.get("arima_order")
     if order is None:


### PR DESCRIPTION
## Summary
- fill missing monthly values with zero in lead scoring preprocessing
- ensure ARIMA training handles NaN values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68400e28caf88332a7e5a89c3054b473