### PR TITLE
Fix tree model metrics in lead scoring

### DIFF
--- a/pred_lead_scoring/train_lead_models.py
+++ b/pred_lead_scoring/train_lead_models.py
@@ -383,6 +383,13 @@ def train_xgboost_lead(
         verbose=params.get("verbose", False),
     )
 
+    val_pred = model_xgb.predict_proba(X_val)[:, 1]
+    pd.Series(val_pred).to_csv(data_dir / "proba_xgboost.csv", index=False)
+    metrics_summary = {
+        "logloss": log_loss(y_val, val_pred),
+        "auc": roc_auc_score(y_val, val_pred),
+    }
+
     model_path = out_dir / "models" / "lead_xgb.pkl"
     model_path.parent.mkdir(parents=True, exist_ok=True)
     joblib.dump(model_xgb, model_path)
@@ -441,6 +448,13 @@ def train_catboost_lead(
     model_cat.fit(
         X_train, y_train, eval_set=(X_val, y_val), verbose=params.get("verbose", False)
     )
+
+    val_pred = model_cat.predict_proba(X_val)[:, 1]
+    pd.Series(val_pred).to_csv(data_dir / "proba_catboost.csv", index=False)
+    metrics_summary = {
+        "logloss": log_loss(y_val, val_pred),
+        "auc": roc_auc_score(y_val, val_pred),
+    }
 
     model_path = out_dir / "models" / "lead_catboost.cbm"
     model_path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- compute validation metrics for XGBoost and CatBoost

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684092e08de88332a044b62187444428