### PR TITLE
Implement create_internal_features

### DIFF
--- a/feature_engineering.py
+++ b/feature_engineering.py
@@ -29,9 +29,53 @@ def create_internal_features(
     train, val, test : pd.DataFrame
         Raw datasets split into training, validation and testing sets.
     lead_cfg : dict
-        Configuration dictionary describing the lead scoring setup.
+        Configuration dictionary describing the lead scoring setup. The
+        function is designed to augment ``train``, ``val`` and ``test`` in
+        place with new descriptive variables that do not depend on the target
+        column.
+
+    Notes
+    -----
+    The following features are created when the relevant columns are present:
+
+    ``month`` and ``year``
+        Extracted from ``lead_cfg["date_col"]``.
+
+    ``duree_entre_debut_fin``
+        Number of days between ``Date de début actualisée`` and
+        ``Date de fin réelle``.
+
+    Missing values are replaced with ``0`` so that subsequent encoding steps do
+    not produce NaNs. ``lead_cfg['numeric_features']`` is updated with the names
+    of the newly created features if necessary.
     """
-    pass
+    if not isinstance(lead_cfg, dict):
+        raise TypeError("lead_cfg must be a dictionary")
+
+    date_col = lead_cfg.get("date_col")
+    if date_col and date_col in train.columns:
+        for df in (train, val, test):
+            if date_col not in df.columns:
+                continue
+            dates = pd.to_datetime(df[date_col], errors="coerce")
+            df["month"] = dates.dt.month.fillna(0).astype(int)
+            df["year"] = dates.dt.year.fillna(0).astype(int)
+
+    duration_cols = {"Date de début actualisée", "Date de fin réelle"}
+    if duration_cols <= set(train.columns):
+        for df in (train, val, test):
+            if not duration_cols <= set(df.columns):
+                continue
+            start = pd.to_datetime(df["Date de début actualisée"], errors="coerce")
+            end = pd.to_datetime(df["Date de fin réelle"], errors="coerce")
+            df["duree_entre_debut_fin"] = (end - start).dt.days.fillna(0.0)
+
+    # Update numeric_features list with the newly created features
+    num_feats = lead_cfg.get("numeric_features", [])
+    for feat in ["month", "year", "duree_entre_debut_fin"]:
+        if feat in train.columns and feat not in num_feats:
+            num_feats.append(feat)
+    lead_cfg["numeric_features"] = num_feats
 
 
 def reduce_categorical_levels(


### PR DESCRIPTION
## Summary
- compute additional calendar and duration features for lead scoring
- update numeric feature list with new columns

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684168ea1f28833295e64e7e346a09d1