### PR TITLE
Add feat_eng option to lead_scoring config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -227,6 +227,7 @@ lead_scoring:
   # Colonne date utilisée pour le split chronologique
   date_col: "Date de fin actualisée"
   cross_val: true
+  feat_eng: true  # Active le pipeline avancé de feature engineering (module feature_engineering.py)
 
   # 4) Liste des variables catégorielles
   cat_features:


### PR DESCRIPTION
## Summary
- enable advanced feature engineering pipeline through new `feat_eng` option

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684169192578833281671fbe52181fda