### PR TITLE
Fix categorical reduction when NaN present

### DIFF
--- a/pred_lead_scoring/feature_engineering.py
+++ b/pred_lead_scoring/feature_engineering.py
@@ -72,13 +72,14 @@ def reduce_categorical_levels(
             continue
         counts = train[col].value_counts(dropna=False)
         frequent = set(counts[counts >= min_freq].index)
+        frequent_no_nan = [x for x in frequent if pd.notna(x)]
 
         for df in (train, val, test):
             if col not in df.columns:
                 continue
             series = df[col]
-            series = series.where(series.isin(frequent), "Autre")
-            df[col] = pd.Categorical(series, categories=list(frequent) + ["Autre"])
+            series = series.where(series.isin(frequent_no_nan), "Autre")
+            df[col] = pd.Categorical(series, categories=frequent_no_nan + ["Autre"])
 
 
 def enrich_with_sirene(

--- a/tests/test_feature_engineering.py
+++ b/tests/test_feature_engineering.py
@@ -143,6 +143,18 @@ def test_reduce_categorical_levels(sample_data):
     assert list(test["category"]) == ["B", "Autre"]
 
 
+def test_reduce_categorical_levels_with_nan():
+    train = pd.DataFrame({"category": ["A", "B", np.nan, "B", np.nan]})
+    val = train.iloc[:2].copy()
+    test = train.iloc[2:].copy()
+
+    fe.reduce_categorical_levels(train, val, test, "category", min_freq=2)
+
+    for df in (train, val, test):
+        assert not df["category"].isna().any()
+        assert set(df["category"].cat.categories) == {"B", "Autre"}
+
+
 def test_enrich_with_sirene(sample_data, monkeypatch):
     train, val, test = sample_data
     sirene_calls, geo_calls = _fake_requests(monkeypatch)


### PR DESCRIPTION
## Summary
- avoid adding NaN values to categorical levels
- test handling of NaN values in reduce_categorical_levels

## Testing
- `pytest -q tests/test_feature_engineering.py`

------
https://chatgpt.com/codex/tasks/task_e_68418b82e1a083328b8cea821fd3a845