### PR TITLE
Remove CatBoost console output

### DIFF
--- a/pred_aggregated_amount/catboost_forecast.py
+++ b/pred_aggregated_amount/catboost_forecast.py
@@ -109,6 +109,7 @@ def rolling_forecast_catboost(
             depth=6,
             random_seed=42,
             verbose=False,
+            logging_level="Silent",
             thread_count=os.cpu_count(),
         )
         model.fit(X_train, y_train, cat_features=cat_feat)
@@ -172,6 +173,7 @@ def forecast_future_catboost(
         depth=6,
         random_seed=42,
         verbose=False,
+        logging_level="Silent",
         thread_count=os.cpu_count(),
     )
     model_full.fit(X_full, y_full, cat_features=cat_feat)

--- a/pred_lead_scoring/train_lead_models.py
+++ b/pred_lead_scoring/train_lead_models.py
@@ -444,6 +444,9 @@ def train_catboost_lead(
     params.setdefault(
         "thread_count", lead_cfg.get("catboost_params", {}).get("thread_count", 1)
     )
+    # Ensure CatBoost does not spam progress lines to stdout
+    params.setdefault("verbose", False)
+    params.setdefault("logging_level", "Silent")
 
     if lead_cfg.get("fine_tuning", False):
         grid = {


### PR DESCRIPTION
## Summary
- suppress progress lines in `train_lead_models.py`
- silence CatBoost regressors in `catboost_forecast.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68419308f7d08332b4e56d3d71c3dbdf