### PR TITLE
Fix CatBoost verbose/logging conflict

### DIFF
--- a/pred_lead_scoring/train_lead_models.py
+++ b/pred_lead_scoring/train_lead_models.py
@@ -453,8 +453,10 @@ def train_catboost_lead(
         "thread_count", lead_cfg.get("catboost_params", {}).get("thread_count", 1)
     )
     # Ensure CatBoost does not spam progress lines to stdout
-    params.setdefault("verbose", False)
-    params.setdefault("logging_level", "Silent")
+    if not any(
+        key in params for key in ("verbose", "verbose_eval", "silent", "logging_level")
+    ):
+        params["verbose"] = False
 
     if lead_cfg.get("fine_tuning", False):
         grid = {


### PR DESCRIPTION
## Summary
- update CatBoost training parameters to avoid passing both `verbose` and `logging_level`
- ensure only one verbosity-related parameter is set by default

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68419cc14b5c8332b7d92df408ad38c9