### PR TITLE
Improve feature engineering and caching

### DIFF
--- a/feature_engineering.py
+++ b/feature_engineering.py
@@ -36,11 +36,16 @@ def advanced_feature_engineering(*args, **kwargs):
     return _call_with_patched_requests(_fe.advanced_feature_engineering, *args, **kwargs)
 
 
+def clear_caches(*args, **kwargs):
+    return _fe.clear_caches(*args, **kwargs)
+
+
 __all__ = [
     "create_internal_features",
     "reduce_categorical_levels",
     "enrich_with_sirene",
     "enrich_with_geo_data",
     "advanced_feature_engineering",
+    "clear_caches",
 ]
 


### PR DESCRIPTION
## Summary
- add API response caching and cache reset helper
- compute status change feature
- implement configurable categorical encoding
- cap numeric outliers and guard against leakage
- test caching logic

## Testing
- `pytest tests/test_feature_engineering.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6841a08b67488332b6b9142ed1c44c96