### PR TITLE
Improve lead scoring models

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -228,7 +228,7 @@ lead_scoring:
   date_col: "Date de fin actualisée"
 
   # Fonctionnalités à mettre en oeuvre
-  imbal_target: true
+  imbalance_strategy: both
   fine_tuning: true
   cross_val: false # redondante si fine_tuning à true
   feat_eng: true  # Active le pipeline avancé de feature engineering (module feature_engineering.py)
@@ -261,7 +261,7 @@ lead_scoring:
   logistic_params:
    C: 1.0
 
-  lstm_params:
+  mlp_params:
    batch_size: 32
    epochs: 50
    patience: 5

--- a/pred_lead_scoring/evaluate_lead_models.py
+++ b/pred_lead_scoring/evaluate_lead_models.py
@@ -67,7 +67,7 @@ def evaluate_lead_models(
 
     log_model = joblib.load(models_dir / "lead_logistic.pkl")
 
-    lstm_model = tf.keras.models.load_model(models_dir / "lead_lstm.h5")
+    mlp_model = tf.keras.models.load_model(models_dir / "lead_mlp.h5")
 
     with open(models_dir / "arima_conv_rate.pkl", "rb") as fh:
         arima_model = pickle.load(fh)
@@ -107,7 +107,11 @@ def evaluate_lead_models(
     _add_clf("xgboost", xgb_model.predict_proba(X_test)[:, 1])
     _add_clf("catboost", cat_model.predict_proba(X_test)[:, 1])
     _add_clf("logistic", log_model.predict_proba(X_test)[:, 1])
-    _add_clf("lstm", lstm_model.predict(X_test).ravel())
+    _add_clf("mlp", mlp_model.predict(X_test).ravel())
+    ensemble_proba = (
+        xgb_model.predict_proba(X_test)[:, 1] + cat_model.predict_proba(X_test)[:, 1]
+    ) / 2
+    _add_clf("ensemble", ensemble_proba)
 
     # ------------------------------------------------------------------
     # Forecast models

--- a/pred_lead_scoring/run_lead_scoring.py
+++ b/pred_lead_scoring/run_lead_scoring.py
@@ -9,7 +9,7 @@ training routines can be parallelised:
 
 - ``train_xgboost_lead``
 - ``train_catboost_lead``
-- ``train_lstm_lead``
+- ``train_mlp_lead``
 
 The two forecasting models, ``train_arima_conv_rate`` and
 ``train_prophet_conv_rate``, may also run concurrently after preprocessing.
@@ -33,8 +33,8 @@ from .train_lead_models import (
     train_xgboost_lead,
     train_catboost_lead,
     train_logistic_lead,
-    train_lstm_lead,
-    train_logistic_lead,
+    train_mlp_lead,
+    train_ensemble_lead,
     train_arima_conv_rate,
     train_prophet_conv_rate,
 )
@@ -77,13 +77,16 @@ def main(argv: list[str] | None = None) -> None:
         fut_xgb = ex.submit(train_xgboost_lead, cfg, X_train, y_train, X_val, y_val)
         fut_cat = ex.submit(train_catboost_lead, cfg, X_train, y_train, X_val, y_val)
         fut_log = ex.submit(train_logistic_lead, cfg, X_train, y_train, X_val, y_val)
-        fut_lstm = ex.submit(train_lstm_lead, cfg, X_train, y_train, X_val, y_val)
+        fut_mlp = ex.submit(train_mlp_lead, cfg, X_train, y_train, X_val, y_val)
 
         # Retrieve results to surface potential exceptions from worker threads
         fut_xgb.result()
         fut_cat.result()
         fut_log.result()
-        fut_lstm.result()
+        fut_mlp.result()
+
+    # Ensemble model using trained XGBoost and CatBoost
+    train_ensemble_lead(cfg, X_val, y_val)
 
     # ------------------------------------------------------------------
     # Forecast models

--- a/tests/test_feature_engineering.py
+++ b/tests/test_feature_engineering.py
@@ -301,7 +301,8 @@ def test_run_lead_scoring_pipeline(tmp_path, monkeypatch):
         "train_xgboost_lead",
         "train_catboost_lead",
         "train_logistic_lead",
-        "train_lstm_lead",
+        "train_mlp_lead",
+        "train_ensemble_lead",
         "train_arima_conv_rate",
         "train_prophet_conv_rate",
     ]:


### PR DESCRIPTION
## Summary
- rename train_lstm_lead -> train_mlp_lead
- broaden hyperparameter search and increase BayesSearch iterations
- add imbalance_strategy option and cross-validation support
- use CatBoost categorical handling
- add simple ensemble model
- update config and tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841a09631348332abec2361b6367409