### PR TITLE
Fix import error in lead scoring run script

### DIFF
--- a/pred_lead_scoring/run_lead_scoring.py
+++ b/pred_lead_scoring/run_lead_scoring.py
@@ -34,7 +34,6 @@ from .train_lead_models import (
     train_xgboost_lead,
     train_catboost_lead,
     train_logistic_lead,
-    train_lstm_lead,
     train_arima_conv_rate,
     train_prophet_conv_rate,
 )


### PR DESCRIPTION
## Summary
- remove unused `train_lstm_lead` import from lead scoring pipeline script

## Testing
- `pytest -q` *(fails: statsforecast missing)*

------
https://chatgpt.com/codex/tasks/task_e_6841a546a5cc83328f9515fb62b01768