### PR TITLE
Fix missing import in lead scoring script

### DIFF
--- a/pred_lead_scoring/run_lead_scoring.py
+++ b/pred_lead_scoring/run_lead_scoring.py
@@ -34,6 +34,8 @@ from .train_lead_models import (
     train_xgboost_lead,
     train_catboost_lead,
     train_logistic_lead,
+    train_mlp_lead,
+    train_ensemble_lead,
     train_arima_conv_rate,
     train_prophet_conv_rate,
 )


### PR DESCRIPTION
## Summary
- import `train_mlp_lead` and `train_ensemble_lead` in `run_lead_scoring`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841ada389708332a0ff8c44fc70d220