### PR TITLE
Redirect training output to file

### DIFF
--- a/pred_lead_scoring/evaluate_lead_models.py
+++ b/pred_lead_scoring/evaluate_lead_models.py
@@ -168,7 +168,7 @@ if __name__ == "__main__":  # pragma: no cover - simple CLI
     import argparse
     import yaml
 
-    setup_logging()
+    setup_logging(log_file="training_output.txt")
 
     p = argparse.ArgumentParser(description="Evaluate lead scoring models")
     p.add_argument("--config", default="config.yaml", help="Path to YAML config")

--- a/pred_lead_scoring/logging_utils.py
+++ b/pred_lead_scoring/logging_utils.py
@@ -2,17 +2,65 @@ from __future__ import annotations
 
 import logging
 import warnings
+import sys
+import io
+from typing import Optional
 from rich.logging import RichHandler
 
 
-def setup_logging(level: int = logging.INFO) -> None:
-    """Configure Rich logging and silence noisy warnings."""
+class _SuppressConsoleNoise(logging.Filter):
+    """Filter out verbose training messages from the console output."""
+
+    def filter(self, record: logging.LogRecord) -> bool:  # pragma: no cover - simple filter
+        msg = record.getMessage()
+        if "learn:" in msg:
+            return False
+        if "The objective has been evaluated at this point before" in msg:
+            return False
+        return True
+
+
+class _StreamToLogger(io.TextIOBase):
+    """Redirect writes to a logger."""
+
+    def __init__(self, logger: logging.Logger, level: int) -> None:
+        super().__init__()
+        self.logger = logger
+        self.level = level
+
+    def write(self, message: str) -> int:  # pragma: no cover - thin wrapper
+        message = message.strip()
+        if message:
+            for line in message.splitlines():
+                self.logger.log(self.level, line)
+        return len(message)
+
+    def flush(self) -> None:  # pragma: no cover - required for file-like API
+        pass
+
+
+def setup_logging(level: int = logging.INFO, log_file: Optional[str] = None) -> None:
+    """Configure logging to write to ``log_file`` and keep the console clean."""
+
+    handlers: list[logging.Handler] = []
+    if log_file is not None:
+        file_handler = logging.FileHandler(log_file, encoding="utf-8")
+        file_handler.setLevel(logging.DEBUG)
+        handlers.append(file_handler)
+
+    console_handler = RichHandler(rich_tracebacks=True)
+    console_handler.setLevel(level)
+    console_handler.addFilter(_SuppressConsoleNoise())
+    handlers.append(console_handler)
+
     logging.basicConfig(
-        level=level,
+        level=logging.DEBUG,
         format="%(message)s",
         datefmt="[%X]",
-        handlers=[RichHandler(rich_tracebacks=True)],
+        handlers=handlers,
     )
+
+    logging.captureWarnings(True)
 
     warnings.filterwarnings("ignore", category=FutureWarning)
     warnings.filterwarnings(
@@ -25,4 +73,15 @@ def setup_logging(level: int = logging.INFO) -> None:
         message=".*force_all_finite.*renamed.*",
         category=FutureWarning,
     )
+
+    if log_file is not None:
+        stdout_logger = logging.getLogger("STDOUT")
+        stderr_logger = logging.getLogger("STDERR")
+        stdout_logger.setLevel(logging.INFO)
+        stderr_logger.setLevel(logging.ERROR)
+        for handler in handlers:
+            stdout_logger.addHandler(handler)
+            stderr_logger.addHandler(handler)
+        sys.stdout = _StreamToLogger(stdout_logger, logging.INFO)
+        sys.stderr = _StreamToLogger(stderr_logger, logging.ERROR)
 

--- a/pred_lead_scoring/preprocess_lead_scoring.py
+++ b/pred_lead_scoring/preprocess_lead_scoring.py
@@ -537,7 +537,7 @@ def preprocess(cfg: Dict[str, Dict]):
 
 
 def main(argv: list[str] | None = None) -> None:
-    setup_logging()
+    setup_logging(log_file="training_output.txt")
     p = argparse.ArgumentParser(description="Preprocess lead scoring dataset")
     p.add_argument("--config", default="config.yaml", help="Path to YAML config")
     args = p.parse_args(argv)

--- a/pred_lead_scoring/run_lead_scoring.py
+++ b/pred_lead_scoring/run_lead_scoring.py
@@ -46,7 +46,7 @@ logger = logging.getLogger(__name__)
 
 
 def main(argv: list[str] | None = None) -> None:
-    setup_logging()
+    setup_logging(log_file="training_output.txt")
     p = argparse.ArgumentParser(description="Run full lead scoring pipeline")
     p.add_argument("--config", default="config.yaml", help="Path to YAML config")
     args = p.parse_args(argv)


### PR DESCRIPTION
## Summary
- log training progress and warnings to `training_output.txt`
- filter noisy progress lines from console output
- use new log file in lead scoring CLI scripts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841b2082680833296bb2ef4155824b6