### PR TITLE
Optimize model training with multiprocessing

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -251,12 +251,13 @@ lead_scoring:
 
   # 6) Paramètres spécifiques XGBoost / CatBoost / LSTM / ARIMA / Prophet
   xgb_params:
-   n_estimators: 100
-   max_depth: 5
+  n_estimators: 100
+  max_depth: 5
+  n_jobs: -1
 
   catboost_params:
    learning_rate: 0.1
-   thread_count: 4
+   thread_count: 12
 
   logistic_params:
    C: 1.0
@@ -265,8 +266,8 @@ lead_scoring:
    batch_size: 32
    epochs: 50
    patience: 5
-   intra_threads: 1
-   inter_threads: 1
+   intra_threads: 4
+   inter_threads: 4
    learning_rate: 0.001
 
   arima_params:

--- a/pred_lead_scoring/run_lead_scoring.py
+++ b/pred_lead_scoring/run_lead_scoring.py
@@ -74,7 +74,7 @@ def main(argv: list[str] | None = None) -> None:
     # ------------------------------------------------------------------
     # Classification models
     # ------------------------------------------------------------------
-    with concurrent.futures.ThreadPoolExecutor(max_workers=4) as ex:
+    with concurrent.futures.ProcessPoolExecutor(max_workers=4) as ex:
         fut_xgb = ex.submit(train_xgboost_lead, cfg, X_train, y_train, X_val, y_val)
         fut_cat = ex.submit(train_catboost_lead, cfg, X_train, y_train, X_val, y_val)
         fut_log = ex.submit(train_logistic_lead, cfg, X_train, y_train, X_val, y_val)
@@ -92,7 +92,7 @@ def main(argv: list[str] | None = None) -> None:
     # ------------------------------------------------------------------
     # Forecast models
     # ------------------------------------------------------------------
-    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as ex:
+    with concurrent.futures.ProcessPoolExecutor(max_workers=2) as ex:
         fut_arima = ex.submit(
             train_arima_conv_rate,
             cfg,

--- a/pred_lead_scoring/train_lead_models.py
+++ b/pred_lead_scoring/train_lead_models.py
@@ -24,6 +24,7 @@ from sklearn.model_selection import GridSearchCV, TimeSeriesSplit
 from skopt import BayesSearchCV
 from skopt.space import Integer, Real
 import concurrent.futures
+import multiprocessing as mp
 
 import tensorflow as tf
 from keras import layers, Model
@@ -130,7 +131,10 @@ def train_mlp_lead(
     lead_cfg = cfg.get("lead_scoring", {})
     out_dir = Path(lead_cfg.get("output_dir", cfg.get("output_dir", ".")))
     data_dir = out_dir / "data_cache"
-    mlp_params = lead_cfg.get("mlp_params", {})
+    mlp_params = lead_cfg.get("mlp_params", {}).copy()
+    default_threads = max(1, mp.cpu_count())
+    mlp_params.setdefault("intra_threads", default_threads)
+    mlp_params.setdefault("inter_threads", default_threads)
     cross_val = lead_cfg.get("cross_val", False)
 
     # ------------------------------------------------------------------
@@ -361,7 +365,7 @@ def train_xgboost_lead(
         y_val = pd.read_csv(data_dir / "y_val.csv").squeeze()
 
     params = lead_cfg.get("xgb_params", {}).copy()
-    params.setdefault("n_jobs", lead_cfg.get("xgb_params", {}).get("n_jobs", 1))
+    params.setdefault("n_jobs", -1)
 
     if lead_cfg.get("fine_tuning", False):
         grid = {
@@ -487,9 +491,7 @@ def train_catboost_lead(
     X_val = X_val.loc[y_val.index]
 
     params = lead_cfg.get("catboost_params", {}).copy()
-    params.setdefault(
-        "thread_count", lead_cfg.get("catboost_params", {}).get("thread_count", 1)
-    )
+    params.setdefault("thread_count", mp.cpu_count())
     # Ensure CatBoost does not spam progress lines to stdout
     if not any(
         key in params for key in ("verbose", "verbose_eval", "silent", "logging_level")


### PR DESCRIPTION
## Summary
- adjust XGBoost to use all CPU cores by default
- let CatBoost use all available cores
- increase TensorFlow threads for the MLP
- switch to `ProcessPoolExecutor` for concurrent training
- update default values in `config.yaml`

## Testing
- `pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6841b218e8388332a71c71e7d47b57a5