### PR TITLE
Fix CatBoost hyperparameter search

### DIFF
--- a/pred_lead_scoring/train_lead_models.py
+++ b/pred_lead_scoring/train_lead_models.py
@@ -451,7 +451,6 @@ def train_catboost_lead(
 
     params = lead_cfg.get("catboost_params", {}).copy()
     params.setdefault("thread_count", mp.cpu_count())
-    params.setdefault("silent", True)
     params.setdefault("logging_level", "Silent")
     # Ensure CatBoost does not spam progress lines to stdout
     if not any(


### PR DESCRIPTION
## Summary
- avoid passing multiple verbosity settings to CatBoost

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842a310d8e0833280f47949ebf04807