### PR TITLE
Fix CatBoost ensemble prediction

### DIFF
--- a/pred_lead_scoring/train_lead_models.py
+++ b/pred_lead_scoring/train_lead_models.py
@@ -602,6 +602,10 @@ def train_ensemble_lead(
     if X_val is None or y_val is None:
         X_val = pd.read_csv(data_dir / "X_val.csv")
         y_val = pd.read_csv(data_dir / "y_val.csv").squeeze()
+    cat_cols = lead_cfg.get("cat_features", [])
+    for col in cat_cols:
+        if col in X_val.columns:
+            X_val[col] = X_val[col].astype(int)
 
     xgb = joblib.load(models_dir / "lead_xgb.pkl")
     cat = CatBoostClassifier()


### PR DESCRIPTION
## Summary
- ensure categorical columns are integers during ensemble inference

## Testing
- `pytest tests/test_feature_engineering.py::test_run_lead_scoring_pipeline -q`

------
https://chatgpt.com/codex/tasks/task_e_6842a6c24e348332a4b8c41c7a55614f