### PR TITLE
Fix CatBoost inference for categorical features

### DIFF
--- a/pred_lead_scoring/evaluate_lead_models.py
+++ b/pred_lead_scoring/evaluate_lead_models.py
@@ -113,6 +113,12 @@ def evaluate_lead_models(
     for col in X_test.select_dtypes(include="object").columns:
         X_test[col] = X_test[col].astype("category")
 
+    # CatBoost requiert des variables catégorielles au format entier ou chaîne
+    cat_cols = lead_cfg.get("cat_features", [])
+    for col in cat_cols:
+        if col in X_test.columns:
+            X_test[col] = X_test[col].astype(int)
+
     preds = {
         "xgboost": xgb_model.predict_proba(X_test)[:, 1],
         "catboost": cat_model.predict_proba(X_test)[:, 1],


### PR DESCRIPTION
## Summary
- cast categorical columns to integers before CatBoost inference

## Testing
- `flake8`
- `pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6842ac62d1148332a8c2f0bd969e6917