### PR TITLE
Add external data utilities

### DIFF
--- a/pred_aggregated_amount/external_data.py
+++ b/pred_aggregated_amount/external_data.py
@@ -1,0 +1,58 @@
+"""Utilities to load and align external open data series."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict
+
+import pandas as pd
+
+
+def load_external_series(
+    path: str | Path,
+    *,
+    date_col: str,
+    value_col: str,
+    freq: str = "M",
+) -> pd.Series:
+    """Return a monthly series from the CSV at ``path``.
+
+    Parameters
+    ----------
+    path:
+        Local path or URL to the CSV file.
+    date_col:
+        Name of the column containing the dates.
+    value_col:
+        Column with the numeric values to use.
+    freq:
+        Resampling frequency (default: monthly ``"M"``).
+    """
+    df = pd.read_csv(path)
+    df[date_col] = pd.to_datetime(df[date_col], errors="coerce")
+    df = df.dropna(subset=[date_col])
+    series = df.set_index(date_col)[value_col].astype(float)
+    series = series.sort_index().asfreq(freq)
+    return series
+
+
+def align_exogenous(
+    target: pd.Series, exog: Dict[str, pd.Series], *, method: str = "linear"
+) -> pd.DataFrame:
+    """Return DataFrame of exogenous variables aligned on ``target`` index."""
+    df = pd.DataFrame(index=target.index)
+    for name, ser in exog.items():
+        aligned = ser.reindex(target.index)
+        if aligned.isna().any():
+            aligned = aligned.interpolate(method=method).fillna(method="bfill").fillna(method="ffill")
+        df[name] = aligned
+    return df
+
+
+def merge_target_exog(target: pd.Series, exog: Dict[str, pd.Series]) -> pd.DataFrame:
+    """Return DataFrame with target and aligned exogenous variables."""
+    exog_df = align_exogenous(target, exog)
+    exog_df.insert(0, "y", target)
+    return exog_df
+
+
+__all__ = ["load_external_series", "align_exogenous", "merge_target_exog"]

--- a/tests/test_external_data.py
+++ b/tests/test_external_data.py
@@ -1,0 +1,28 @@
+import pandas as pd
+from pred_aggregated_amount.external_data import align_exogenous, merge_target_exog
+from pred_aggregated_amount.train_xgboost import _to_supervised
+
+
+def test_align_exogenous_basic():
+    target = pd.Series(
+        [1, 2, 3], index=pd.date_range("2020-01-01", periods=3, freq="M")
+    )
+    ex1 = pd.Series(
+        [10, 20, 30], index=pd.date_range("2020-01-01", periods=3, freq="M")
+    )
+    df = align_exogenous(target, {"ex": ex1})
+    assert list(df.columns) == ["ex"]
+    pd.testing.assert_index_equal(df.index, target.index)
+
+
+def test_merge_target_exog_and_supervised():
+    target = pd.Series(
+        [1, 2, 3, 4, 5], index=pd.date_range("2020-01-01", periods=5, freq="M")
+    )
+    ex = pd.Series(
+        [0, 1, 0, 1, 0], index=pd.date_range("2020-01-01", periods=5, freq="M")
+    )
+    df = merge_target_exog(target, {"flag": ex})
+    X, y = _to_supervised(df["y"], 2, add_time_features=False, exog=df[["flag"]])
+    assert "flag" in X.columns
+    assert len(X) == len(y)


### PR DESCRIPTION
## Summary
- add module to load and align open data series
- extend `_to_supervised` helper to handle exogenous variables
- test new utilities

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6842d06bd5248332b4d27f4f9a5034b2