### PR TITLE
Fix revenue resampling bug

### DIFF
--- a/pred_aggregated_amount/preprocess_dates.py
+++ b/pred_aggregated_amount/preprocess_dates.py
@@ -129,9 +129,11 @@ def impute_with_model(
 # ---------------------------------------------------------------------------
 
 def filter_won(df: pd.DataFrame) -> pd.DataFrame:
-    """Return copy of ``df`` only with won opportunities and valid dates."""
+    """Return subset of won opportunities with the closing date as index."""
     out = df[df["Statut commercial"] == "Gagné"].copy()
     out = out.dropna(subset=["Date de fin actualisée"])
+    out = out.sort_values("Date de fin actualisée")
+    out = out.set_index("Date de fin actualisée")
     return out
 
 


### PR DESCRIPTION
## Summary
- ensure the subset of won opportunities has the closing date as index

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842e29213b08332b65a9f6ef08ec33c