### PR TITLE
Fix CatBoost logging level conflict

### DIFF
--- a/pred_aggregated_amount/catboost_forecast.py
+++ b/pred_aggregated_amount/catboost_forecast.py
@@ -108,7 +108,6 @@ def rolling_forecast_catboost(
             learning_rate=0.1,
             depth=6,
             random_seed=42,
-            verbose=False,
             logging_level="Silent",
             thread_count=os.cpu_count() or 1,
         )
@@ -172,7 +171,6 @@ def forecast_future_catboost(
         learning_rate=0.1,
         depth=6,
         random_seed=42,
-        verbose=False,
         logging_level="Silent",
         thread_count=os.cpu_count() or 1,
     )


### PR DESCRIPTION
## Summary
- remove `verbose` argument to avoid catboost parameter conflict

## Testing
- `pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6842ec8a5a748332b59cb7b1a5e87391