### PR TITLE
Enable default time series cross‑validation

### DIFF
--- a/pred_aggregated_amount/evaluate_models.py
+++ b/pred_aggregated_amount/evaluate_models.py
@@ -211,7 +211,7 @@ def evaluate_all_models(
     quarterly: pd.Series,
     yearly: pd.Series,
     *,
-    cross_val: bool = False,
+    cross_val: bool = True,
     n_splits: int = 5,
 ) -> Dict[str, Dict[str, Dict[str, float]]]:
     """Return MAE, RMSE and MAPE for all models and granularities."""

--- a/pred_aggregated_amount/run_all.py
+++ b/pred_aggregated_amount/run_all.py
@@ -215,6 +215,7 @@ def main(argv: list[str] | None = None) -> None:
     p.add_argument(
         "--cross-val",
         action="store_true",
+        default=True,
         help="Activer la validation croisee temporelle",
     )
     p.add_argument(


### PR DESCRIPTION
## Summary
- enable temporal CV flag by default when running `pred_aggregated_amount/run_all.py`
- set the evaluation helper `evaluate_all_models` to use cross‑validation by default

## Testing
- `pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6843230faebc8332b0b338672c600279