### PR TITLE
Fix CSV reading and plotting for tests

### DIFF
--- a/pred_aggregated_amount/make_plots.py
+++ b/pred_aggregated_amount/make_plots.py
@@ -1,6 +1,9 @@
 from pathlib import Path
 
 import pandas as pd
+import matplotlib
+
+matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 
 from .preprocess_timeseries import load_and_aggregate, preprocess_all

--- a/pred_aggregated_amount/preprocess_dates.py
+++ b/pred_aggregated_amount/preprocess_dates.py
@@ -22,7 +22,7 @@ def load_csv(path: str | Path) -> pd.DataFrame:
     path = Path(path)
     if not path.is_file():
         raise FileNotFoundError(f"{path} does not exist")
-    df = pd.read_csv(path)
+    df = pd.read_csv(path, encoding="utf-8")
     for col in ["Date de fin actualisée", "Date de début actualisée", "Date de fin réelle"]:
         if col in df.columns:
             # The data is stored in ISO format so ``dayfirst`` should be False


### PR DESCRIPTION
## Summary
- ensure CSVs are read with UTF-8
- use Agg backend for matplotlib to avoid Tk errors
- include backend setup in plots module

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843390e76948332be35889a11cb5df0