### PR TITLE
Fix csv loading on non-UTF8 locales

### DIFF
--- a/pred_aggregated_amount/preprocess_dates.py
+++ b/pred_aggregated_amount/preprocess_dates.py
@@ -22,7 +22,11 @@ def load_csv(path: str | Path) -> pd.DataFrame:
     path = Path(path)
     if not path.is_file():
         raise FileNotFoundError(f"{path} does not exist")
-    df = pd.read_csv(path, encoding="utf-8")
+    try:
+        df = pd.read_csv(path, encoding="utf-8")
+    except UnicodeDecodeError:
+        # Fall back to latin-1 for environments using a different locale
+        df = pd.read_csv(path, encoding="latin-1")
     for col in ["Date de fin actualisée", "Date de début actualisée", "Date de fin réelle"]:
         if col in df.columns:
             # The data is stored in ISO format so ``dayfirst`` should be False


### PR DESCRIPTION
## Summary
- make load_csv resilient to non UTF-8 input files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68433aa0052c8332b804c0d79648e7da