### PR TITLE
Handle CatBoost constant series

### DIFF
--- a/pred_aggregated_amount/catboost_forecast.py
+++ b/pred_aggregated_amount/catboost_forecast.py
@@ -148,6 +148,21 @@ def forecast_future_catboost(
     if CatBoostRegressor is None:
         raise ImportError("catboost is required for CatBoost forecasting")
 
+    if series_clean.nunique() == 1:
+        # CatBoost cannot train on a constant series. Simply repeat the last
+        # value for the requested horizon.
+        last_date = series_clean.index[-1]
+        future_dates = pd.date_range(
+            start=last_date + pd.tseries.frequencies.to_offset(freq),
+            periods=horizon or 1,
+            freq=freq,
+        )
+        const_val = float(series_clean.iloc[-1])
+        return pd.DataFrame(
+            {"yhat_catboost": [const_val] * len(future_dates)},
+            index=future_dates,
+        )
+
     df_sup = prepare_supervised(series_clean, freq)
 
     if horizon is None:

--- a/pred_aggregated_amount/evaluate_models.py
+++ b/pred_aggregated_amount/evaluate_models.py
@@ -188,6 +188,9 @@ def _evaluate_catboost(
     series: pd.Series, freq: str, *, test_size: int | None = None
 ) -> Dict[str, float]:
     """Evaluate CatBoost model with rolling forecast."""
+    if series.nunique() == 1:
+        raise ValueError("CatBoost cannot train on a constant series")
+
     df_sup = prepare_supervised(series, freq)
     preds, actuals = rolling_forecast_catboost(df_sup, freq, test_size=test_size)
     return _compute_metrics(actuals, preds)

--- a/tests/test_forecasting_utils.py
+++ b/tests/test_forecasting_utils.py
@@ -153,6 +153,13 @@ def test_forecast_future_catboost(monkeypatch):
     assert len(res) == 2
 
 
+def test_forecast_future_catboost_constant(monkeypatch):
+    monkeypatch.setattr(cb, "CatBoostRegressor", DummyCat, raising=False)
+    series = pd.Series([5.0] * 12, index=pd.date_range("2020-01-31", periods=12, freq="M"))
+    res = cb.forecast_future_catboost(series, "M", horizon=3)
+    assert (res["yhat_catboost"] == 5.0).all()
+
+
 # ---------------------------------------------------------------------------
 # Plotting and pipeline
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- revert bad CatBoost workaround
- skip CatBoost evaluation when the series is constant
- repeat the last value when forecasting constant series
- test constant CatBoost forecast

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68454671b6848332999dbad5d9fba296