### PR TITLE
Merge evaluate_all implementations

### DIFF
--- a/pred_aggregated_amount/evaluate_models.py
+++ b/pred_aggregated_amount/evaluate_models.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import Callable, Dict, List, Tuple
+import concurrent.futures
 
 import numpy as np
 import pandas as pd
@@ -232,64 +233,144 @@ def _ts_cross_val(
 # Public API
 # ---------------------------------------------------------------------------
 
+def _eval_arima(m, q, y, *, cross_val: bool, n_splits: int) -> Dict[str, Dict[str, float]]:
+    if cross_val:
+        cv = lambda s, **kw: _ts_cross_val(s, _evaluate_arima, n_splits=n_splits, **kw)
+        return {
+            "monthly": cv(m, seasonal=True, m=12),
+            "quarterly": cv(q, seasonal=True, m=4),
+            "yearly": cv(y, seasonal=False, m=1),
+        }
+    return {
+        "monthly": _evaluate_arima(m, 12, seasonal=True, m=12),
+        "quarterly": _evaluate_arima(q, 4, seasonal=True, m=4),
+        "yearly": _evaluate_arima(y, 3, seasonal=False, m=1),
+    }
+
+
+def _eval_prophet(m, q, y, *, cross_val: bool, n_splits: int) -> Dict[str, Dict[str, float]]:
+    if cross_val:
+        cv = lambda s, **kw: _ts_cross_val(s, _evaluate_prophet, n_splits=n_splits, **kw)
+        return {
+            "monthly": cv(m, yearly_seasonality=True),
+            "quarterly": cv(q, yearly_seasonality=True),
+            "yearly": cv(y, yearly_seasonality=False),
+        }
+    return {
+        "monthly": _evaluate_prophet(m, 12, yearly_seasonality=True),
+        "quarterly": _evaluate_prophet(q, 4, yearly_seasonality=True),
+        "yearly": _evaluate_prophet(y, 3, yearly_seasonality=False),
+    }
+
+
+def _eval_xgb(m, q, y, *, cross_val: bool, n_splits: int) -> Dict[str, Dict[str, float]]:
+    if cross_val:
+        cv = lambda s, **kw: _ts_cross_val(s, _evaluate_xgb, n_splits=n_splits, **kw)
+        return {
+            "monthly": cv(m, n_lags=12, add_time_features=True),
+            "quarterly": cv(q, n_lags=4, add_time_features=True),
+            "yearly": cv(y, n_lags=3, add_time_features=False),
+        }
+    return {
+        "monthly": _evaluate_xgb(m, 12, n_lags=12, add_time_features=True),
+        "quarterly": _evaluate_xgb(q, 4, n_lags=4, add_time_features=True),
+        "yearly": _evaluate_xgb(y, 3, n_lags=3, add_time_features=False),
+    }
+
+
+def _eval_lstm(m, q, y, *, cross_val: bool, n_splits: int) -> Dict[str, Dict[str, float]]:
+    if cross_val:
+        cv = lambda s, **kw: _ts_cross_val(s, _evaluate_lstm, n_splits=n_splits, **kw)
+        return {
+            "monthly": cv(m, window=12),
+            "quarterly": cv(q, window=4),
+            "yearly": cv(y, window=3),
+        }
+    return {
+        "monthly": _evaluate_lstm(m, 12, window=12),
+        "quarterly": _evaluate_lstm(q, 4, window=4),
+        "yearly": _evaluate_lstm(y, 3, window=3),
+    }
+
+
+def _eval_catboost(m, q, y, *, cross_val: bool, n_splits: int) -> Dict[str, Dict[str, float]]:
+    if cross_val:
+        cv = lambda s, f: _ts_cross_val(
+            s,
+            lambda ser, ts, *, freq=f: _evaluate_catboost(ser, freq, test_size=ts),
+            n_splits=n_splits,
+        )
+        return {
+            "monthly": cv(m, "M"),
+            "quarterly": cv(q, "Q"),
+            "yearly": cv(y, "A"),
+        }
+
+    if m.nunique() == 1 and q.nunique() == 1 and y.nunique() == 1:
+        zero = {"MAE": 0.0, "RMSE": 0.0, "MAPE": 0.0}
+        return {"monthly": zero, "quarterly": zero, "yearly": zero}
+
+    dfm = prepare_supervised(m, freq="M")
+    dfq = prepare_supervised(q, freq="Q")
+    dfy = prepare_supervised(y, freq="A")
+
+    preds_m, actuals_m = rolling_forecast_catboost(dfm, freq="M")
+    preds_q, actuals_q = rolling_forecast_catboost(dfq, freq="Q")
+    preds_y, actuals_y = rolling_forecast_catboost(dfy, freq="A")
+
+    return {
+        "monthly": _compute_metrics(actuals_m, preds_m),
+        "quarterly": _compute_metrics(actuals_q, preds_q),
+        "yearly": _compute_metrics(actuals_y, preds_y),
+    }
+
+
+EVAL_FUNCS = {
+    "ARIMA": _eval_arima,
+    "Prophet": _eval_prophet,
+    "XGBoost": _eval_xgb,
+    "LSTM": _eval_lstm,
+    "CatBoost": _eval_catboost,
+}
+
+
 def evaluate_all_models(
     monthly: pd.Series,
     quarterly: pd.Series,
     yearly: pd.Series,
     *,
+    jobs: int = 1,
     cross_val: bool = True,
     n_splits: int = 5,
 ) -> Dict[str, Dict[str, Dict[str, float]]]:
     """Return MAE, RMSE and MAPE for all models and granularities."""
-    results: Dict[str, Dict[str, Dict[str, float]]] = {
-        "ARIMA": {"monthly": {}, "quarterly": {}, "yearly": {}},
-        "Prophet": {"monthly": {}, "quarterly": {}, "yearly": {}},
-        "XGBoost": {"monthly": {}, "quarterly": {}, "yearly": {}},
-        "LSTM": {"monthly": {}, "quarterly": {}, "yearly": {}},
-        "CatBoost": {"monthly": {}, "quarterly": {}, "yearly": {}},
-    }
-
-    if cross_val:
-        cv = lambda s, fn, **kw: _ts_cross_val(s, fn, n_splits=n_splits, **kw)
-        results["ARIMA"]["monthly"] = cv(monthly, _evaluate_arima, seasonal=True, m=12)
-        results["Prophet"]["monthly"] = cv(monthly, _evaluate_prophet, yearly_seasonality=True)
-        results["XGBoost"]["monthly"] = cv(monthly, _evaluate_xgb, n_lags=12, add_time_features=True)
-        results["LSTM"]["monthly"] = cv(monthly, _evaluate_lstm, window=12)
-        results["CatBoost"]["monthly"] = cv(monthly, _evaluate_catboost, freq="M")
-
-        results["ARIMA"]["quarterly"] = cv(quarterly, _evaluate_arima, seasonal=True, m=4)
-        results["Prophet"]["quarterly"] = cv(quarterly, _evaluate_prophet, yearly_seasonality=True)
-        results["XGBoost"]["quarterly"] = cv(quarterly, _evaluate_xgb, n_lags=4, add_time_features=True)
-        results["LSTM"]["quarterly"] = cv(quarterly, _evaluate_lstm, window=4)
-        results["CatBoost"]["quarterly"] = cv(quarterly, _evaluate_catboost, freq="Q")
-
-        results["ARIMA"]["yearly"] = cv(yearly, _evaluate_arima, seasonal=False, m=1)
-        results["Prophet"]["yearly"] = cv(yearly, _evaluate_prophet, yearly_seasonality=False)
-        results["XGBoost"]["yearly"] = cv(yearly, _evaluate_xgb, n_lags=3, add_time_features=False)
-        results["LSTM"]["yearly"] = cv(yearly, _evaluate_lstm, window=3)
-        results["CatBoost"]["yearly"] = cv(yearly, _evaluate_catboost, freq="A")
+    results: Dict[str, Dict[str, Dict[str, float]]] = {}
+    if jobs > 1:
+        with concurrent.futures.ProcessPoolExecutor(max_workers=jobs) as ex:
+            futs = {
+                ex.submit(func, monthly, quarterly, yearly, cross_val=cross_val, n_splits=n_splits): name
+                for name, func in EVAL_FUNCS.items()
+            }
+            for fut in concurrent.futures.as_completed(futs):
+                name = futs[fut]
+                try:
+                    results[name] = fut.result()
+                except Exception as exc:  # pragma: no cover - passthrough
+                    print(f"{name} failed: {exc}")
+                    results[name] = {}
     else:
-        # Monthly: last 12 months for testing
-        results["ARIMA"]["monthly"] = _evaluate_arima(monthly, 12, seasonal=True, m=12)
-        results["Prophet"]["monthly"] = _evaluate_prophet(monthly, 12, yearly_seasonality=True)
-        results["XGBoost"]["monthly"] = _evaluate_xgb(monthly, 12, n_lags=12, add_time_features=True)
-        results["LSTM"]["monthly"] = _evaluate_lstm(monthly, 12, window=12)
-        results["CatBoost"]["monthly"] = _evaluate_catboost(monthly, "M")
-
-        # Quarterly: last 4 quarters for testing
-        results["ARIMA"]["quarterly"] = _evaluate_arima(quarterly, 4, seasonal=True, m=4)
-        results["Prophet"]["quarterly"] = _evaluate_prophet(quarterly, 4, yearly_seasonality=True)
-        results["XGBoost"]["quarterly"] = _evaluate_xgb(quarterly, 4, n_lags=4, add_time_features=True)
-        results["LSTM"]["quarterly"] = _evaluate_lstm(quarterly, 4, window=4)
-        results["CatBoost"]["quarterly"] = _evaluate_catboost(quarterly, "Q")
-
-        # Yearly: last 3 years for testing
-        results["ARIMA"]["yearly"] = _evaluate_arima(yearly, 3, seasonal=False, m=1)
-        results["Prophet"]["yearly"] = _evaluate_prophet(yearly, 3, yearly_seasonality=False)
-        results["XGBoost"]["yearly"] = _evaluate_xgb(yearly, 3, n_lags=3, add_time_features=False)
-        results["LSTM"]["yearly"] = _evaluate_lstm(yearly, 3, window=3)
-        results["CatBoost"]["yearly"] = _evaluate_catboost(yearly, "A")
-
+        for name, func in EVAL_FUNCS.items():
+            try:
+                results[name] = func(
+                    monthly,
+                    quarterly,
+                    yearly,
+                    cross_val=cross_val,
+                    n_splits=n_splits,
+                )
+            except Exception as exc:  # pragma: no cover - passthrough
+                print(f"{name} failed: {exc}")
+                results[name] = {}
     return results
 
 

--- a/pred_aggregated_amount/run_all.py
+++ b/pred_aggregated_amount/run_all.py
@@ -30,175 +30,15 @@ warnings.filterwarnings(
 )
 
 import argparse
-import concurrent.futures
 from pathlib import Path
-from typing import Dict
 
 import yaml
 
 from .preprocess_timeseries import preprocess_all
 from .preprocess_dates import preprocess_dates
-from .evaluate_models import (
-    _evaluate_arima,
-    _evaluate_prophet,
-    _evaluate_xgb,
-    _evaluate_catboost,
-    _evaluate_lstm,
-    _compute_metrics,
-    _ts_cross_val,
-)
-from .catboost_forecast import (
-    prepare_supervised,
-    rolling_forecast_catboost,
-)
+from .evaluate_models import evaluate_all_models
 from .compare_granularities import build_performance_table
 from .make_plots import main as make_plots_main
-
-
-# ---------------------------------------------------------------------------
-# Evaluation helpers
-# ---------------------------------------------------------------------------
-
-
-def _eval_arima(m, q, y, *, cross_val: bool, n_splits: int) -> Dict[str, Dict[str, float]]:
-    if cross_val:
-        cv = lambda s, **kw: _ts_cross_val(s, _evaluate_arima, n_splits=n_splits, **kw)
-        return {
-            "monthly": cv(m, seasonal=True, m=12),
-            "quarterly": cv(q, seasonal=True, m=4),
-            "yearly": cv(y, seasonal=False, m=1),
-        }
-    return {
-        "monthly": _evaluate_arima(m, 12, seasonal=True, m=12),
-        "quarterly": _evaluate_arima(q, 4, seasonal=True, m=4),
-        "yearly": _evaluate_arima(y, 3, seasonal=False, m=1),
-    }
-
-
-def _eval_prophet(m, q, y, *, cross_val: bool, n_splits: int) -> Dict[str, Dict[str, float]]:
-    if cross_val:
-        cv = lambda s, **kw: _ts_cross_val(s, _evaluate_prophet, n_splits=n_splits, **kw)
-        return {
-            "monthly": cv(m, yearly_seasonality=True),
-            "quarterly": cv(q, yearly_seasonality=True),
-            "yearly": cv(y, yearly_seasonality=False),
-        }
-    return {
-        "monthly": _evaluate_prophet(m, 12, yearly_seasonality=True),
-        "quarterly": _evaluate_prophet(q, 4, yearly_seasonality=True),
-        "yearly": _evaluate_prophet(y, 3, yearly_seasonality=False),
-    }
-
-
-def _eval_xgb(m, q, y, *, cross_val: bool, n_splits: int) -> Dict[str, Dict[str, float]]:
-    if cross_val:
-        cv = lambda s, **kw: _ts_cross_val(s, _evaluate_xgb, n_splits=n_splits, **kw)
-        return {
-            "monthly": cv(m, n_lags=12, add_time_features=True),
-            "quarterly": cv(q, n_lags=4, add_time_features=True),
-            "yearly": cv(y, n_lags=3, add_time_features=False),
-        }
-    return {
-        "monthly": _evaluate_xgb(m, 12, n_lags=12, add_time_features=True),
-        "quarterly": _evaluate_xgb(q, 4, n_lags=4, add_time_features=True),
-        "yearly": _evaluate_xgb(y, 3, n_lags=3, add_time_features=False),
-    }
-
-
-def _eval_lstm(m, q, y, *, cross_val: bool, n_splits: int) -> Dict[str, Dict[str, float]]:
-    if cross_val:
-        cv = lambda s, **kw: _ts_cross_val(s, _evaluate_lstm, n_splits=n_splits, **kw)
-        return {
-            "monthly": cv(m, window=12),
-            "quarterly": cv(q, window=4),
-            "yearly": cv(y, window=3),
-        }
-    return {
-        "monthly": _evaluate_lstm(m, 12, window=12),
-        "quarterly": _evaluate_lstm(q, 4, window=4),
-        "yearly": _evaluate_lstm(y, 3, window=3),
-    }
-
-
-def _eval_catboost(m, q, y, *, cross_val: bool, n_splits: int) -> Dict[str, Dict[str, float]]:
-    if cross_val:
-        cv = lambda s, f: _ts_cross_val(
-            s,
-            lambda ser, ts, *, freq=f: _evaluate_catboost(ser, freq, test_size=ts),
-            n_splits=n_splits,
-        )
-        return {
-            "monthly": cv(m, "M"),
-            "quarterly": cv(q, "Q"),
-            "yearly": cv(y, "A"),
-        }
-
-    if m.nunique() == 1 and q.nunique() == 1 and y.nunique() == 1:
-        zero = {"MAE": 0.0, "RMSE": 0.0, "MAPE": 0.0}
-        return {"monthly": zero, "quarterly": zero, "yearly": zero}
-
-    dfm = prepare_supervised(m, freq="M")
-    dfq = prepare_supervised(q, freq="Q")
-    dfy = prepare_supervised(y, freq="A")
-
-    preds_m, actuals_m = rolling_forecast_catboost(dfm, freq="M")
-    preds_q, actuals_q = rolling_forecast_catboost(dfq, freq="Q")
-    preds_y, actuals_y = rolling_forecast_catboost(dfy, freq="A")
-
-    return {
-        "monthly": _compute_metrics(actuals_m, preds_m),
-        "quarterly": _compute_metrics(actuals_q, preds_q),
-        "yearly": _compute_metrics(actuals_y, preds_y),
-    }
-
-
-EVAL_FUNCS = {
-    "ARIMA": _eval_arima,
-    "Prophet": _eval_prophet,
-    "XGBoost": _eval_xgb,
-    "LSTM": _eval_lstm,
-    "CatBoost": _eval_catboost,
-}
-
-
-def evaluate_all(
-    m,
-    q,
-    y,
-    *,
-    jobs: int,
-    cross_val: bool,
-    n_splits: int = 5,
-) -> Dict[str, Dict[str, Dict[str, float]]]:
-    """Return metrics for each model in parallel when ``jobs`` > 1."""
-    results: Dict[str, Dict[str, Dict[str, float]]] = {}
-    if jobs > 1:
-        with concurrent.futures.ProcessPoolExecutor(max_workers=jobs) as ex:
-            futs = {
-                ex.submit(func, m, q, y, cross_val=cross_val, n_splits=n_splits): name
-                for name, func in EVAL_FUNCS.items()
-            }
-            for fut in concurrent.futures.as_completed(futs):
-                name = futs[fut]
-                try:
-                    results[name] = fut.result()
-                except Exception as exc:  # pragma: no cover - passthrough
-                    print(f"{name} failed: {exc}")
-                    results[name] = {}
-    else:
-        for name, func in EVAL_FUNCS.items():
-            try:
-                results[name] = func(
-                    m,
-                    q,
-                    y,
-                    cross_val=cross_val,
-                    n_splits=n_splits,
-                )
-            except Exception as exc:  # pragma: no cover - passthrough
-                print(f"{name} failed: {exc}")
-                results[name] = {}
-    return results
 
 
 # ---------------------------------------------------------------------------
@@ -255,7 +95,7 @@ def main(argv: list[str] | None = None) -> None:
 
     monthly, quarterly, yearly = preprocess_all(monthly, quarterly, yearly)
 
-    results = evaluate_all(
+    results = evaluate_all_models(
         monthly,
         quarterly,
         yearly,


### PR DESCRIPTION
## Summary
- move multiprocessing evaluation logic into `evaluate_models.evaluate_all_models`
- use the unified function from `run_all`
- remove obsolete helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68454e0fae5483329fbf50697f904b08