### PR TITLE
Clean optional imports

### DIFF
--- a/pred_aggregated_amount/__init__.py
+++ b/pred_aggregated_amount/__init__.py
@@ -18,35 +18,8 @@ from .lstm_forecast import (
     train_lstm_model,
     quick_predict_check,
 )
-
-try:  # Optional dependency
-    from .prophet_models import fit_prophet_models  # type: ignore
-except Exception as _exc_prophet:  # pragma: no cover - optional
-
-    def fit_prophet_models(*_a, **_k):
-        raise ImportError(
-            "prophet is required for fit_prophet_models"  # noqa: B904
-        ) from _exc_prophet
-
-
-try:  # Optional dependency
-    from .train_arima import fit_all_arima  # type: ignore
-except Exception as _exc_arima:  # pragma: no cover - optional
-
-    def fit_all_arima(*_a, **_k):
-        raise ImportError("statsforecast is required for fit_all_arima") from _exc_arima
-
-
 from .train_xgboost import train_xgb_model, train_all_granularities
 from .compare_granularities import build_performance_table, plot_metric_comparison
-
-# Prophet-related helpers are optional to avoid hard dependency during tests
-try:  # pragma: no cover - import may fail when Prophet is missing
-    from .prophet_models import fit_prophet_models
-    from .future_forecast import forecast_prophet
-except Exception:  # pragma: no cover - keep usable without Prophet
-    fit_prophet_models = None
-    forecast_prophet = None
 from .future_forecast import (
     forecast_arima,
     forecast_xgb,
@@ -57,6 +30,24 @@ from .catboost_forecast import (
     rolling_forecast_catboost,
     forecast_future_catboost,
 )
+
+
+def fit_prophet_models(*args, **kwargs):
+    from .prophet_models import fit_prophet_models as _fit
+
+    return _fit(*args, **kwargs)
+
+
+def fit_all_arima(*args, **kwargs):
+    from .train_arima import fit_all_arima as _fit
+
+    return _fit(*args, **kwargs)
+
+
+def forecast_prophet(*args, **kwargs):
+    from .future_forecast import forecast_prophet as _forecast
+
+    return _forecast(*args, **kwargs)
 
 __all__ = [
     "load_won_opportunities",
@@ -82,10 +73,6 @@ __all__ = [
     "prepare_supervised",
     "rolling_forecast_catboost",
     "forecast_future_catboost",
+    "fit_prophet_models",
+    "forecast_prophet",
 ]
-
-if fit_prophet_models is not None:
-    __all__.insert(6, "fit_prophet_models")
-
-if forecast_prophet is not None:
-    __all__.insert(-3, "forecast_prophet")

--- a/pred_aggregated_amount/catboost_forecast.py
+++ b/pred_aggregated_amount/catboost_forecast.py
@@ -7,15 +7,13 @@ import os
 
 import numpy as np
 import pandas as pd
-try:  # pragma: no cover - optional dependency
-    from catboost import CatBoostRegressor
-except Exception:  # pragma: no cover - handle missing lib
-    CatBoostRegressor = None
 from sklearn.metrics import (
     mean_absolute_error,
     mean_squared_error,
     mean_absolute_percentage_error,
 )
+
+CatBoostRegressor = None
 
 
 # ---------------------------------------------------------------------------
@@ -105,8 +103,10 @@ def rolling_forecast_catboost(
     preds: List[float] = []
     actuals: List[float] = []
 
+    global CatBoostRegressor
     if CatBoostRegressor is None:
-        raise ImportError("catboost is required for CatBoost forecasting")
+        from catboost import CatBoostRegressor as _Cat
+        CatBoostRegressor = _Cat
 
     for i in range(n_test):
         X_train = df_train.drop(columns=["y"]).copy()
@@ -161,8 +161,10 @@ def forecast_future_catboost(
 ) -> pd.DataFrame:
     """Iteratively forecast ``horizon`` future periods with CatBoost."""
 
+    global CatBoostRegressor
     if CatBoostRegressor is None:
-        raise ImportError("catboost is required for CatBoost forecasting")
+        from catboost import CatBoostRegressor as _Cat
+        CatBoostRegressor = _Cat
 
     if series_clean.nunique() == 1:
         # CatBoost cannot train on a constant series. Simply repeat the last

--- a/pred_aggregated_amount/future_forecast.py
+++ b/pred_aggregated_amount/future_forecast.py
@@ -3,22 +3,19 @@
 from __future__ import annotations
 
 import pandas as pd
-
-try:  # Optional dependency
-    from statsforecast.models import AutoARIMA
-except Exception as _exc_arima:  # pragma: no cover - optional
-    AutoARIMA = None
-try:  # Optional dependency
-    from prophet import Prophet
-except Exception as _exc_prophet:  # pragma: no cover - optional
-    Prophet = None
-try:  # Optional dependency
-    from xgboost import XGBRegressor
-except Exception as _exc_xgb:  # pragma: no cover - optional
-    XGBRegressor = None
 from sklearn.preprocessing import MinMaxScaler
+from typing import TYPE_CHECKING
 
 from .train_xgboost import _to_supervised
+
+if TYPE_CHECKING:  # pragma: no cover - optional type hints
+    from prophet import Prophet
+    from statsforecast.models import AutoARIMA
+    from xgboost import XGBRegressor
+
+AutoARIMA = None
+Prophet = None
+XGBRegressor = None
 
 
 # ---------------------------------------------------------------------------
@@ -26,10 +23,8 @@ from .train_xgboost import _to_supervised
 # ---------------------------------------------------------------------------
 
 
-def forecast_arima(model: AutoARIMA, series: pd.Series, periods: int) -> pd.DataFrame:
+def forecast_arima(model: "AutoARIMA", series: pd.Series, periods: int) -> pd.DataFrame:
     """Return ARIMA predictions with confidence intervals."""
-    if AutoARIMA is None:
-        raise ImportError("statsforecast is required for forecast_arima") from _exc_arima
     freq = series.index.freq or pd.infer_freq(series.index)
     if freq is None:
         raise ValueError("Series index must have a frequency")
@@ -55,10 +50,8 @@ def forecast_arima(model: AutoARIMA, series: pd.Series, periods: int) -> pd.Data
 # ---------------------------------------------------------------------------
 
 
-def forecast_prophet(model: Prophet, series: pd.Series, periods: int) -> pd.DataFrame:
+def forecast_prophet(model: "Prophet", series: pd.Series, periods: int) -> pd.DataFrame:
     """Return Prophet predictions with confidence intervals."""
-    if Prophet is None:
-        raise ImportError("prophet is required for forecast_prophet") from _exc_prophet
     freq = series.index.freq or pd.infer_freq(series.index) or "M"
     future = model.make_future_dataframe(periods=periods, freq=freq)
     forecast = model.predict(future)
@@ -74,7 +67,7 @@ def forecast_prophet(model: Prophet, series: pd.Series, periods: int) -> pd.Data
 
 
 def forecast_xgb(
-    model: XGBRegressor,
+    model: "XGBRegressor",
     series: pd.Series,
     periods: int,
     *,
@@ -83,8 +76,6 @@ def forecast_xgb(
     add_time_features: bool = True,
 ) -> pd.DataFrame:
     """Iteratively forecast with XGBoost and approximate confidence bounds."""
-    if XGBRegressor is None:
-        raise ImportError("xgboost is required for forecast_xgb") from _exc_xgb
     freq = series.index.freq or pd.infer_freq(series.index)
     if freq is None:
         raise ValueError("Series index must have a frequency")

--- a/pred_aggregated_amount/train_arima.py
+++ b/pred_aggregated_amount/train_arima.py
@@ -6,13 +6,10 @@ from typing import Tuple
 
 import pandas as pd
 
-# ``AutoARIMA`` performs a grid-search over different (p, d, q) orders and
-# optionally seasonal orders to minimise the AIC.  It returns an already fitted
-# model.
-try:  # Optional dependency
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - type hints
     from statsforecast.models import AutoARIMA
-except Exception as _exc_arima:  # pragma: no cover - optional
-    AutoARIMA = None
 
 
 # ---------------------------------------------------------------------------
@@ -20,7 +17,7 @@ except Exception as _exc_arima:  # pragma: no cover - optional
 # ---------------------------------------------------------------------------
 
 
-def _fit_series(series: pd.Series, *, seasonal: bool, m: int) -> AutoARIMA:
+def _fit_series(series: pd.Series, *, seasonal: bool, m: int) -> "AutoARIMA":
     """Return the best ARIMA/SARIMA model for ``series``.
 
     Parameters
@@ -34,8 +31,7 @@ def _fit_series(series: pd.Series, *, seasonal: bool, m: int) -> AutoARIMA:
     m : int
         Number of observations per cycle for the seasonal component.
     """
-    if AutoARIMA is None:
-        raise ImportError("statsforecast is required for ARIMA models") from _exc_arima
+    from statsforecast.models import AutoARIMA
 
     season_length = m if seasonal else 1
     model = AutoARIMA(season_length=season_length)
@@ -47,7 +43,7 @@ def fit_all_arima(
     monthly: pd.Series,
     quarterly: pd.Series,
     yearly: pd.Series,
-) -> Tuple[AutoARIMA, AutoARIMA, AutoARIMA]:
+) -> Tuple["AutoARIMA", "AutoARIMA", "AutoARIMA"]:
     """Fit ARIMA/SARIMA models for monthly, quarterly and yearly series."""
     # Monthly data has an obvious yearly cycle -> SARIMA with m=12
     model_monthly = _fit_series(monthly, seasonal=True, m=12)


### PR DESCRIPTION
## Summary
- refactor optional imports in `pred_aggregated_amount`
- rely on lazy imports for heavy libraries
- expose placeholder classes for tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68454e2d628c8332b693cdb42d6f207c