### PR TITLE
Centralize revenue forecast paths

### DIFF
--- a/pred_aggregated_amount/config.py
+++ b/pred_aggregated_amount/config.py
@@ -1,0 +1,22 @@
+"""Shared configuration for revenue forecasting."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import yaml
+
+
+# Path to the repository root
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_CFG_FILE = _REPO_ROOT / "config.yaml"
+
+try:
+    with open(_CFG_FILE, "r", encoding="utf-8") as fh:
+        _CFG = yaml.safe_load(fh) or {}
+except FileNotFoundError:  # pragma: no cover - fallback when missing
+    _CFG = {}
+
+INPUT_CSV: Path = Path(_CFG.get("input_file_cleaned_3_all", "phase3_cleaned_all.csv"))
+OUTPUT_DIR: Path = Path(_CFG.get("output_dir", "output_dir"))
+
+__all__ = ["INPUT_CSV", "OUTPUT_DIR"]

--- a/pred_aggregated_amount/preprocess_dates.py
+++ b/pred_aggregated_amount/preprocess_dates.py
@@ -6,6 +6,8 @@ from pathlib import Path
 from typing import Tuple, Dict
 import logging
 
+from .config import INPUT_CSV, OUTPUT_DIR
+
 from .aggregate_revenue import aggregate_revenue
 
 import pandas as pd
@@ -189,7 +191,9 @@ def save_summary(info: Dict[str, int], out_dir: Path) -> None:
 # Main orchestration
 # ---------------------------------------------------------------------------
 
-def preprocess_dates(csv_path: str | Path, output_dir: str | Path = "output_dir") -> Tuple[pd.Series, pd.Series, pd.Series]:
+def preprocess_dates(
+    csv_path: str | Path = INPUT_CSV, output_dir: str | Path = OUTPUT_DIR
+) -> Tuple[pd.Series, pd.Series, pd.Series]:
     """Full pipeline returning aggregated revenue series."""
     out_dir = Path(output_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -250,8 +254,16 @@ if __name__ == "__main__":  # pragma: no cover - simple CLI
     import argparse
 
     parser = argparse.ArgumentParser(description="Preprocess closing dates")
-    parser.add_argument("csv", help="Path to phase3_cleaned_multivariate.csv")
-    parser.add_argument("--output-dir", default="output_dir", help="Destination for figures and summary")
+    parser.add_argument(
+        "--csv",
+        default=str(INPUT_CSV),
+        help="Path to phase3_cleaned_multivariate.csv",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=str(OUTPUT_DIR),
+        help="Destination for figures and summary",
+    )
     args = parser.parse_args()
 
     preprocess_dates(args.csv, args.output_dir)

--- a/pred_aggregated_amount/run_all.py
+++ b/pred_aggregated_amount/run_all.py
@@ -14,7 +14,7 @@ Training and evaluation of each model run in parallel when several
 
 Usage::
 
-    python -m pred.run_all --config config.yaml [--jobs N]
+    python -m pred_aggregated_amount.run_all [--jobs N]
 """
 from __future__ import annotations
 
@@ -31,10 +31,9 @@ warnings.filterwarnings(
 
 import argparse
 import concurrent.futures
-from pathlib import Path
 from typing import Dict
 
-import yaml
+from .config import INPUT_CSV, OUTPUT_DIR
 
 from .preprocess_timeseries import preprocess_all
 from .preprocess_dates import preprocess_dates
@@ -209,9 +208,6 @@ def evaluate_all(
 def main(argv: list[str] | None = None) -> None:
     p = argparse.ArgumentParser(description="Run forecasting pipeline")
     p.add_argument(
-        "--config", default="config.yaml", help="Fichier de configuration YAML"
-    )
-    p.add_argument(
         "--jobs",
         type=int,
         default=os.cpu_count(),
@@ -231,11 +227,8 @@ def main(argv: list[str] | None = None) -> None:
     )
     args = p.parse_args(argv)
 
-    with open(args.config, "r", encoding="utf-8") as fh:
-        cfg = yaml.safe_load(fh)
-
-    csv_path = Path(cfg.get("input_file_cleaned_3_all", "phase3_cleaned_all.csv"))
-    output_dir = Path(cfg.get("output_dir", "."))
+    csv_path = INPUT_CSV
+    output_dir = OUTPUT_DIR
 
     # ------------------------------------------------------------------
     # Stage 1 - cleaning closing dates before any other transformation


### PR DESCRIPTION
## Summary
- add `config.py` to load the YAML once and expose `INPUT_CSV` and `OUTPUT_DIR`
- rely on those constants in `run_all.py` and `preprocess_dates.py`
- simplify CLIs to use the centralized configuration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68454e3687ec83329adc9726d5fc54a3