### PR TITLE
Update cross-val flag

### DIFF
--- a/pred_aggregated_amount/run_all.py
+++ b/pred_aggregated_amount/run_all.py
@@ -219,10 +219,17 @@ def main(argv: list[str] | None = None) -> None:
     )
     p.add_argument(
         "--cross-val",
+        dest="cross_val",
         action="store_true",
-        default=True,
         help="Activer la validation croisee temporelle",
     )
+    p.add_argument(
+        "--no-cross-val",
+        dest="cross_val",
+        action="store_false",
+        help="Desactiver la validation croisee temporelle",
+    )
+    p.set_defaults(cross_val=False)
     p.add_argument(
         "--n-splits",
         type=int,


### PR DESCRIPTION
## Summary
- make cross validation optional in `run_all.py`
- add complementary `--no-cross-val` flag

## Testing
- `pytest -q`
- `python -m pred_aggregated_amount.run_all --help`
- python snippet checking argument defaults

------
https://chatgpt.com/codex/tasks/task_e_68454e4008b08332b0d5509045b38625